### PR TITLE
MimePart/Entity constructor with content type.

### DIFF
--- a/MimeKit/MimeEntity.cs
+++ b/MimeKit/MimeEntity.cs
@@ -87,8 +87,20 @@ namespace MimeKit {
 		/// <para><paramref name="mediaSubtype"/> is <c>null</c>.</para>
 		/// </exception>
 		protected MimeEntity (string mediaType, string mediaSubtype)
+			: this(new ContentType (mediaType, mediaSubtype))
 		{
-			ContentType = new ContentType (mediaType, mediaSubtype);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MimeKit.MimeEntity"/> class.
+		/// </summary>
+		/// <param name="contentType">The content type.</param>
+		/// <exception cref="System.ArgumentNullException">
+		/// <para><paramref name="contentType"/> is <c>null</c>.</para>
+		/// </exception>
+		protected MimeEntity (ContentType contentType)
+		{
+			ContentType = contentType;
 			Headers = new HeaderList ();
 
 			ContentType.Changed += ContentTypeChanged;

--- a/MimeKit/MimePart.cs
+++ b/MimeKit/MimePart.cs
@@ -125,7 +125,31 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="mediaSubtype"/> is <c>null</c>.</para>
 		/// </exception>
-		public MimePart (string mediaType, string mediaSubtype) : base (mediaType, mediaSubtype)
+		public MimePart (string mediaType, string mediaSubtype) : base (new ContentType (mediaType, mediaSubtype))
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MimeKit.MimePart"/> class
+		/// with the specified content type.
+		/// </summary>
+		/// <param name="contentType">The content type.</param>
+		/// <exception cref="System.ArgumentNullException">
+		/// <para><paramref name="contentType"/> is <c>null</c>.</para>
+		/// </exception>
+		public MimePart (ContentType contentType) : base (contentType)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MimeKit.MimePart"/> class
+		/// with the specified content type.
+		/// </summary>
+		/// <param name="contentType">The content type.</param>
+		/// <exception cref="System.ArgumentNullException">
+		/// <para><paramref name="contentType"/> is <c>null</c>.</para>
+		/// </exception>
+		public MimePart (string contentType) : base (ContentType.Parse(contentType))
 		{
 		}
 


### PR DESCRIPTION
This will allow the creation of a MimePart where you already got a variable such as "image/jpeg".

If accepted I would also like to make similar changes allowing `new TextPart("text/html")` , still backwards compatible with current `new TextPart("html")`
