### PR TITLE
Allow parsing of message with 0 byte body.

### DIFF
--- a/MimeKit/MimeParser.cs
+++ b/MimeKit/MimeParser.cs
@@ -811,7 +811,8 @@ namespace MimeKit {
 			do {
 				if (ReadAhead (inbuf, Math.Max (ReadAheadSize, left), 0) <= left) {
 					// failed to find the end of the headers; EOF reached
-					state = MimeParserState.Error;
+					ParseAndAppendHeader ();
+					state = MimeParserState.Content;
 					inputIndex = inputEnd;
 					return;
 				}


### PR DESCRIPTION
I've come across a few emails without a message body.

The incoming SMTP conversation look something like this:

```
DATA
Date:...
To:...
Subject:....

.
```

This generated a stream ending with "...Subject:...\r\n"

With the suggested changed the message will be parsed.
However I am not too familiar with the code, for example this change could misbehave in a stream ending inside the headers. Still it would be preferred if those messages could be parsed as well.
