### PR TITLE
Fix ChainedStream to handle partial reads

### DIFF
--- a/MimeKit/IO/ChainedStream.cs
+++ b/MimeKit/IO/ChainedStream.cs
@@ -281,14 +281,15 @@ namespace MimeKit.IO {
 			int n, nread = 0;
 
 			while (current < streams.Count) {
-				if ((n = streams[current].Read (buffer, offset + nread, count - nread)) > 0) {
-					nread += n;
 
-					if (nread == count)
-						break;
-				}
+				n = streams[current].Read (buffer, offset + nread, count - nread);
+				nread += n;
 
-				current++;
+				if (nread == count)
+					break;
+
+				if (n==0)
+					current++;
 			}
 
 			if (nread > 0)

--- a/UnitTests/ChainedStreamTests.cs
+++ b/UnitTests/ChainedStreamTests.cs
@@ -69,7 +69,7 @@ namespace UnitTests {
 				lengths.Add (n);
 				position += n;
 
-				chained.Add (new MemoryStream (segment));
+				chained.Add (new ReadOneByteStream(new MemoryStream (segment)));
 			}
 		}
 
@@ -176,6 +176,67 @@ namespace UnitTests {
 			var entity = MimeEntity.Load (chained, true) as TextPart;
 
 			Assert.AreEqual ("Hello, world!\r\n", entity.Text);
+		}
+
+		class ReadOneByteStream : Stream
+		{
+			readonly Stream _inner;
+
+			public ReadOneByteStream(Stream inner)
+			{
+				_inner = inner;
+			}
+
+			public override void Flush()
+			{
+				_inner.Flush();
+			}
+
+			public override long Seek(long offset, SeekOrigin origin)
+			{
+				return _inner.Seek(offset, origin);
+			}
+
+			public override void SetLength(long value)
+			{
+				_inner.SetLength(value);
+			}
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				return _inner.Read(buffer, offset, 1);
+			}
+
+			public override void Write(byte[] buffer, int offset, int count)
+			{
+				_inner.Write(buffer, offset, count);
+			}
+
+			public override bool CanRead
+			{
+				get { return _inner.CanRead; }
+			}
+
+			public override bool CanSeek
+			{
+				get { return _inner.CanSeek; }
+			}
+
+			public override bool CanWrite
+			{
+				get { return _inner.CanWrite; }
+			}
+
+			public override long Length
+			{
+				get { return _inner.Length; }
+			}
+
+			public override long Position
+			{
+				get { return _inner.Position; }
+				set { _inner.Position = value; }
+			}
 		}
 	}
 }


### PR DESCRIPTION
I was working with MimeKit to read an HttpWebResponse and found that the content was not being fully read.  Apparently Stream.Read can return fewer bytes than requested and the response stream will.  This fixes ChainedStream to continue reading until the entire expected read is fulfilled.  An alternative solution would be to pass partial reads through.  

I also modified the ChainedStream tests to utilize a stream that always partial reads.  This causes the last three tests to fail and the fix corrects them.  I wasn't sure if this would be better a separate test or not.  I can also confirm that this did fix my issue with HttpWebResponse.

Let me know if there is anything else I can do to make this a better fit for the project.