### PR TITLE
Adds support additional private key files

### DIFF
--- a/MimeKit/Cryptography/DkimSigner.cs
+++ b/MimeKit/Cryptography/DkimSigner.cs
@@ -140,6 +140,10 @@ namespace MimeKit.Cryptography {
         				if (keyObject is AsymmetricKeyParameter)
         				{
         					key = keyObject as AsymmetricKeyParameter;
+        					if (!key.IsPrivate ())
+        					{
+        						key = null;
+        					}
         				}
             				else if (keyObject is AsymmetricCipherKeyPair)
             				{

--- a/MimeKit/Cryptography/DkimSigner.cs
+++ b/MimeKit/Cryptography/DkimSigner.cs
@@ -129,13 +129,23 @@ namespace MimeKit.Cryptography {
 			if (selector == null)
 				throw new ArgumentNullException ("selector");
 
-			AsymmetricCipherKeyPair key;
+			AsymmetricKeyParameter key;
 
 			using (var stream = File.OpenRead (fileName)) {
 				using (var reader = new StreamReader (stream)) {
 					var pem = new PemReader (reader);
 
-					key = pem.ReadObject () as AsymmetricCipherKeyPair;
+					keyObject = pem.ReadObject ();
+					
+        				if (keyObject is AsymmetricKeyParameter)
+        				{
+        					key = keyObject as AsymmetricKeyParameter;
+        				}
+            				else if (keyObject is AsymmetricCipherKeyPair)
+            				{
+                				var pair = keyObject as AsymmetricCipherKeyPair;
+                				key = pair.Private;
+					}
 				}
 			}
 
@@ -143,7 +153,7 @@ namespace MimeKit.Cryptography {
 				throw new FormatException ("Private key not found.");
 
 			SignatureAlgorithm = DkimSignatureAlgorithm.RsaSha256;
-			PrivateKey = key.Private;
+			PrivateKey = key;
 			Selector = selector;
 			Domain = domain;
 		}

--- a/MimeKit/Cryptography/DkimSigner.cs
+++ b/MimeKit/Cryptography/DkimSigner.cs
@@ -135,7 +135,7 @@ namespace MimeKit.Cryptography {
 				using (var reader = new StreamReader (stream)) {
 					var pem = new PemReader (reader);
 
-					keyObject = pem.ReadObject ();
+					var keyObject = pem.ReadObject ();
 					
         				if (keyObject is AsymmetricKeyParameter)
         				{


### PR DESCRIPTION
This adds support reading additional private key files. For example, when loading PEM files from openssl PemReader returns an RSAPrivateCrtKeyParameters object. This object implements AsymmetricKeyParameter and not AsymmetricCipherKeyPair. With the proposed changes both AsymmetricCipherKeyPair and AsymmetricKeyParameter derived objects are supported.