### PR TITLE
Don't set TextBody to contents of text attach when body undefined

### DIFF
--- a/MimeKit/MimeMessage.cs
+++ b/MimeKit/MimeMessage.cs
@@ -921,7 +921,7 @@ namespace MimeKit {
 			} else {
 				var body = Body as TextPart;
 
-				if (body != null && body.IsFormat (format))
+				if (body != null && body.IsFormat (format) && !body.IsAttachment)
 					return body.Text;
 			}
 

--- a/UnitTests/MimeMessageTests.cs
+++ b/UnitTests/MimeMessageTests.cs
@@ -26,10 +26,10 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Net.Mail;
 using System.Reflection;
-using System.Collections.Generic;
 
 using NUnit.Framework;
 
@@ -872,6 +872,30 @@ Content-ID: <spankulate4@hubba.hubba.hubba>
 			message = MimeMessage.Load (Path.Combine ("..", "..", "TestData", "messages", "body.9.txt"));
 			Assert.AreEqual (null, message.TextBody, "The text bodies do not match for body.9.txt.");
 			Assert.AreEqual (HtmlBody, message.HtmlBody, "The HTML bodies do not match for body.9.txt.");
+		}
+
+		[Test]
+		public void TestNoBodyWithTextAttachment()
+		{
+			const string rawMessageText = @"From: sender@domain.com
+Date: Tue, 29 Aug 2017 09:45:39 +1000
+Subject: This has no body, just a text attachment
+Message-Id: <75SXBEJJ72U4.5KFFZ6J56L2T2@localhost.localdomain>
+MIME-Version: 1.0
+Content-Type: text/plain; name=""Plain Text.txt""
+Content-Disposition: attachment; filename=""Plain Text.txt""
+Content-Transfer-Encoding: 7bit
+
+This is the text attachment";
+
+			using (var source = new MemoryStream(Encoding.UTF8.GetBytes(rawMessageText)))
+			{
+				var parser = new MimeParser(source, MimeFormat.Default);
+				var message = parser.ParseMessage();
+
+				Assert.Null(message.TextBody, "Message text should be blank, as no body defined");
+				Assert.AreEqual(1, message.Attachments.OfType<TextPart>().Count(), "Message should contain one text attachment");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Hi,

When the following mail is parsed:
```
From: sender@domain.com
Date: Tue, 29 Aug 2017 09:45:39 +1000
Subject: This has no body, just a text attachment
Message-Id: <75SXBEJJ72U4.5KFFZ6J56L2T2@localhost.localdomain>
MIME-Version: 1.0
Content-Type: text/plain; name="Plain Text.txt"
Content-Disposition: attachment; filename="Plain Text.txt"
Content-Transfer-Encoding: 7bit

This is the text attachment
```
The Message.TextBody is set to the contents of the attachment, rather than being null as expected.
This is because the message doesn't have any body.  The fix is just to add a `&& !body.IsAttachment` to the condition in `MimeMessage.GetTextBody` on line 924.

I don't believe the RFC states you have to have a body, and email clients render this as expected - a blank message with a small text attachment.

Many thanks!

Ant.