### PR TITLE
Update X509CertificateDatabase.cs

### DIFF
--- a/MimeKit/Cryptography/X509CertificateDatabase.cs
+++ b/MimeKit/Cryptography/X509CertificateDatabase.cs
@@ -132,13 +132,18 @@ namespace MimeKit.Cryptography {
 		static int ReadBinaryBlob (DbDataReader reader, int column, ref byte[] buffer)
 		{
 			long nread;
-
+#if NETSTANDARD
+			buffer= reader.GetFieldValue<byte[]> (column);
+			nread = buffer.Length;
+			return (int) nread;
+#else
 			// first, get the length of the buffer needed
 			if ((nread = reader.GetBytes (column, 0, null, 0, buffer.Length)) > buffer.Length)
 				Array.Resize (ref buffer, (int) nread);
 
 			// read the certificate data
 			return (int) reader.GetBytes (column, 0, buffer, 0, (int) nread);
+#endif
 		}
 
 		static X509Certificate DecodeCertificate (DbDataReader reader, X509CertificateParser parser, int column, ref byte[] buffer)

--- a/MimeKit/Cryptography/X509CertificateDatabase.cs
+++ b/MimeKit/Cryptography/X509CertificateDatabase.cs
@@ -131,12 +131,12 @@ namespace MimeKit.Cryptography {
 
 		static int ReadBinaryBlob (DbDataReader reader, int column, ref byte[] buffer)
 		{
-			long nread;
 #if NETSTANDARD
-			buffer= reader.GetFieldValue<byte[]> (column);
-			nread = buffer.Length;
-			return (int) nread;
+			buffer = reader.GetFieldValue<byte[]> (column);
+			return (int) buffer.Length;
 #else
+			long nread;
+
 			// first, get the length of the buffer needed
 			if ((nread = reader.GetBytes (column, 0, null, 0, buffer.Length)) > buffer.Length)
 				Array.Resize (ref buffer, (int) nread);


### PR DESCRIPTION
Fix: NetStandard does not support method GetBytes, use method GetFieldValue instead