### PR TITLE
TNEF: Save original codepage for future reference

### DIFF
--- a/MimeKit/Tnef/TnefPart.cs
+++ b/MimeKit/Tnef/TnefPart.cs
@@ -383,6 +383,9 @@ namespace MimeKit.Tnef {
 
 			message.Body = builder.ToMessageBody ();
 
+            if(reader.MessageCodepage != 0)
+                message.Headers.Add("X-OriginalCodepage", reader.MessageCodepage.ToString());
+
 			return message;
 		}
 


### PR DESCRIPTION
Office 365 sends quite odd TNEF messages. It often sets OemCodepage attribute to 1251 and specifies real charset of HTML body in meta tag. 
It is not a problem of MimeKit of course, but life can be much easier if ConvertToMessage() method would indicate codepage value it used to extract particular binary property (HTML body of the message).