### PR TITLE
Fixed bug: erroneously detected 'From' as Mbox marker

### DIFF
--- a/MimeKit/MimeParser.cs
+++ b/MimeKit/MimeParser.cs
@@ -576,7 +576,7 @@ namespace MimeKit {
 			if (allowMunged && *inptr == (byte) '>')
 				inptr++;
 
-			return *inptr++ == (byte) 'F' && *inptr++ == (byte) 'r' && *inptr++ == (byte) 'o' && *inptr++ == (byte) 'm' && *inptr == (byte) ' ';
+			return *inptr++ == (byte) 'F' && *inptr++ == (byte) 'r' && *inptr++ == (byte) 'o' && *inptr++ == (byte) 'm' && *inptr++ == (byte) ' ' && *inptr == (byte) '-';
 #endif
 		}
 


### PR DESCRIPTION
I tried to parse my Mbox file generated by Thunderbird. At a certain point the "Formatexception: System.FormatException: Failed to parse message headers." was thrown. The problem wasn't the actual message but it turned out that the message before wasn't parsed correctly.
In this message the function MimeParser::IsMboxMarker erroneously returned true. The reason was that the line coincidently started with 'From ' but it belonged to the message (no mbox marker). I changed it and now it checks for 'From -'.
This doesn't fix the problem because theoretically a line could also start with 'From -'. However, it becomes less likely.