### PR TITLE
AttachDisposition text will come like   inline; filename="imagea429bf…

### DIFF
--- a/MimeKit/Tnef/TnefPart.cs
+++ b/MimeKit/Tnef/TnefPart.cs
@@ -408,10 +408,9 @@ namespace MimeKit.Tnef {
 							break;
 						case TnefPropertyId.AttachDisposition:
 							text = prop.ReadValueAsString ();
-							ContentDisposition contentDisposition;
-							ContentDisposition.TryParse(text, out contentDisposition);
-							attachment.ContentDisposition = contentDisposition;
-									break;
+							if (ContentDisposition.TryParse (text, out ContentDisposition disposition))
+								attachment.ContentDisposition = disposition;
+							break;
 						case TnefPropertyId.AttachData:
 							if (attachMethod == TnefAttachMethod.EmbeddedMessage) {
 								var tnef = new TnefPart ();

--- a/MimeKit/Tnef/TnefPart.cs
+++ b/MimeKit/Tnef/TnefPart.cs
@@ -408,11 +408,10 @@ namespace MimeKit.Tnef {
 							break;
 						case TnefPropertyId.AttachDisposition:
 							text = prop.ReadValueAsString ();
-							if (attachment.ContentDisposition == null)
-								attachment.ContentDisposition = new ContentDisposition (text);
-							else
-								attachment.ContentDisposition.Disposition = text;
-							break;
+							ContentDisposition contentDisposition;
+							ContentDisposition.TryParse(text, out contentDisposition);
+							attachment.ContentDisposition = contentDisposition;
+									break;
 						case TnefPropertyId.AttachData:
 							if (attachMethod == TnefAttachMethod.EmbeddedMessage) {
 								var tnef = new TnefPart ();


### PR DESCRIPTION
AttachDisposition text will come like   inline; filename="imagea429bf.JPG"; and hence it will show error attachment.ContentDisposition.Disposition = text; as there is validation  "Illegal characters in disposition value." for Disposition, please see the  Content-Disposition spec https://tools.ietf.org/html/rfc6266