### PR TITLE
handle body consisting of only a single non-text entity as an attachment

### DIFF
--- a/MimeKit/MimeMessage.cs
+++ b/MimeKit/MimeMessage.cs
@@ -976,9 +976,15 @@ namespace MimeKit {
 		/// <code language="c#" source="Examples\AttachmentExamples.cs" region="SaveAttachments" />
 		/// </example>
 		/// <value>The attachments.</value>
-		public IEnumerable<MimeEntity> Attachments {
-			get { return EnumerateMimeParts (Body).Where (x => x.IsAttachment); }
-		}
+		public IEnumerable<MimeEntity> Attachments
+        {
+            get
+            {
+                return Body is MimePart p && !"text".Equals(p.ContentType.MediaType, StringComparison.OrdinalIgnoreCase)
+                     ? Enumerable.Repeat(Body, 1)
+                     : EnumerateMimeParts(Body).Where(x => x.IsAttachment);
+            }
+        }
 
 		/// <summary>
 		/// Returns a <see cref="System.String"/> that represents the current <see cref="MimeKit.MimeMessage"/>.


### PR DESCRIPTION
I recently switched my custom mail parser that I've been running for almost a decade over to MimeKit, and it's been running great, so thanks! I've found only a single problematic case in the email history I've checked, and it's where the body is empty except for a non-text entity, but whose content disposition header does not designate it as an attachment.

The change I made above straightforwardly only detects this one corner case. Let me know if you'd like to handle it a different way and I'll adapt it. I can provide a sample of this case if you need more clarification.