### PR TITLE
Fixed X509Crl.IsDelta for CRLs without extensions

### DIFF
--- a/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
+++ b/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
@@ -347,9 +347,8 @@ namespace MimeKit.Cryptography {
 		internal static bool IsDelta (this X509Crl crl)
 		{
 			var critical = crl.GetCriticalExtensionOids ();
-			if (critical == null)
-				return false;
-			return critical.Contains (X509Extensions.DeltaCrlIndicator.Id);
+
+			return critical != null ? critical.Contains (X509Extensions.DeltaCrlIndicator.Id) : false;
 		}
 	}
 }

--- a/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
+++ b/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
@@ -347,7 +347,8 @@ namespace MimeKit.Cryptography {
 		internal static bool IsDelta (this X509Crl crl)
 		{
 			var critical = crl.GetCriticalExtensionOids ();
-
+			if (critical == null)
+				return false;
 			return critical.Contains (X509Extensions.DeltaCrlIndicator.Id);
 		}
 	}


### PR DESCRIPTION
Hi,

when using revocation checking, the import for certain CRLs fails, because `GetCriticalExtensionOids()` inside `BouncyCastleCertificateExtensions.IsDelta` returns null for CRLs without any extensions.

This PR should fix this issue.

example: [crl without extensions](http://esignature.telekom.at/taca/crl/serialNumber_16_eSignature_Basic.crl)