### PR TITLE
Add additional MimeFilters to the FormatOptions

### DIFF
--- a/MimeKit/Cryptography/ArcSigner.cs
+++ b/MimeKit/Cryptography/ArcSigner.cs
@@ -317,7 +317,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateSigningContext ())) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
-                    filtered.AddRange(options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 
 					for (int i = 0; i < count; i++) {
 						DkimVerifierBase.WriteHeaderRelaxed (options, filtered, sets[i].ArcAuthenticationResult, false);

--- a/MimeKit/Cryptography/ArcSigner.cs
+++ b/MimeKit/Cryptography/ArcSigner.cs
@@ -270,6 +270,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateSigningContext ())) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
+					filtered.AddRange (options.AdditionalMimeFilters);
 
 					// write the specified message headers
 					DkimVerifierBase.WriteHeaders (options, message, headers, HeaderCanonicalizationAlgorithm, filtered);
@@ -316,6 +317,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateSigningContext ())) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
+                    filtered.AddRange(options.AdditionalMimeFilters);
 
 					for (int i = 0; i < count; i++) {
 						DkimVerifierBase.WriteHeaderRelaxed (options, filtered, sets[i].ArcAuthenticationResult, false);

--- a/MimeKit/Cryptography/ArcVerifier.cs
+++ b/MimeKit/Cryptography/ArcVerifier.cs
@@ -325,6 +325,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateVerifyContext (signatureAlgorithm, key))) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
+					filtered.AddRange (options.AdditionalMimeFilters);
 
 					WriteHeaders (options, message, headers, headerAlgorithm, filtered);
 
@@ -373,6 +374,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateVerifyContext (algorithm, key))) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
+                    filtered.AddRange (options.AdditionalMimeFilters);
 
 					for (int j = 0; j < i; j++) {
 						WriteHeaderRelaxed (options, filtered, sets[j].ArcAuthenticationResult, false);

--- a/MimeKit/Cryptography/ArcVerifier.cs
+++ b/MimeKit/Cryptography/ArcVerifier.cs
@@ -374,7 +374,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateVerifyContext (algorithm, key))) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
-                    filtered.AddRange (options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 
 					for (int j = 0; j < i; j++) {
 						WriteHeaderRelaxed (options, filtered, sets[j].ArcAuthenticationResult, false);

--- a/MimeKit/Cryptography/DkimSigner.cs
+++ b/MimeKit/Cryptography/DkimSigner.cs
@@ -277,7 +277,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateSigningContext ())) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
-                    filtered.AddRange (options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 
 					// write the specified message headers
 					DkimVerifierBase.WriteHeaders (options, message, headers, HeaderCanonicalizationAlgorithm, filtered);

--- a/MimeKit/Cryptography/DkimSigner.cs
+++ b/MimeKit/Cryptography/DkimSigner.cs
@@ -277,6 +277,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateSigningContext ())) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
+                    filtered.AddRange (options.AdditionalMimeFilters);
 
 					// write the specified message headers
 					DkimVerifierBase.WriteHeaders (options, message, headers, HeaderCanonicalizationAlgorithm, filtered);

--- a/MimeKit/Cryptography/DkimVerifier.cs
+++ b/MimeKit/Cryptography/DkimVerifier.cs
@@ -148,7 +148,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateVerifyContext (signatureAlgorithm, key))) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
-                    filtered.AddRange (options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 
 					WriteHeaders (options, message, headers, headerAlgorithm, filtered);
 

--- a/MimeKit/Cryptography/DkimVerifier.cs
+++ b/MimeKit/Cryptography/DkimVerifier.cs
@@ -148,6 +148,7 @@ namespace MimeKit.Cryptography {
 			using (var stream = new DkimSignatureStream (CreateVerifyContext (signatureAlgorithm, key))) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
+                    filtered.AddRange (options.AdditionalMimeFilters);
 
 					WriteHeaders (options, message, headers, headerAlgorithm, filtered);
 

--- a/MimeKit/FormatOptions.cs
+++ b/MimeKit/FormatOptions.cs
@@ -26,7 +26,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using MimeKit.IO.Filters;
 
 namespace MimeKit {
@@ -76,6 +76,7 @@ namespace MimeKit {
 		bool ensureNewLine;
 		bool international;
 		int maxLineLength;
+
 
 		/// <summary>
 		/// The default formatting options.
@@ -193,6 +194,14 @@ namespace MimeKit {
 			get; private set;
 		}
 
+        /// <summary>
+        /// Gets or sets a list of extra mime filters that are invoked when reading or writing a Mime message.
+        /// </summary>
+        /// <para>This is primarily meant for extending writing mime message to a target stream.</para>
+        public IList<IMimeFilter> AdditionalMimeFilters {
+            get; private set;
+        }
+
 		/// <summary>
 		/// Gets or sets whether the new "Internationalized Email" formatting standards should be used.
 		/// </summary>
@@ -279,6 +288,8 @@ namespace MimeKit {
 			}
 		}
 
+
+
 		static FormatOptions ()
 		{
 			Default = new FormatOptions ();
@@ -294,6 +305,7 @@ namespace MimeKit {
 		public FormatOptions ()
 		{
 			HiddenHeaders = new HashSet<HeaderId> ();
+            AdditionalMimeFilters = new List<IMimeFilter>();
 			parameterEncodingMethod = ParameterEncodingMethod.Rfc2231;
 			maxLineLength = DefaultMaxLineLength;
 			allowMixedHeaderCharsets = false;
@@ -320,6 +332,7 @@ namespace MimeKit {
 			options.newLineFormat = newLineFormat;
 			options.ensureNewLine = ensureNewLine;
 			options.HiddenHeaders = new HashSet<HeaderId> (HiddenHeaders);
+            options.AdditionalMimeFilters = new List<IMimeFilter>(AdditionalMimeFilters);
 			options.allowMixedHeaderCharsets = allowMixedHeaderCharsets;
 			options.parameterEncodingMethod = parameterEncodingMethod;
 			options.international = international;

--- a/MimeKit/FormatOptions.cs
+++ b/MimeKit/FormatOptions.cs
@@ -26,7 +26,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using MimeKit.IO.Filters;
 
 namespace MimeKit {
@@ -198,9 +197,9 @@ namespace MimeKit {
         /// Gets or sets a list of extra mime filters that are invoked when reading or writing a Mime message.
         /// </summary>
         /// <para>This is primarily meant for extending writing mime message to a target stream.</para>
-        public IList<IMimeFilter> AdditionalMimeFilters {
-            get; private set;
-        }
+		public IList<IMimeFilter> AdditionalMimeFilters {
+			get; private set;
+		}
 
 		/// <summary>
 		/// Gets or sets whether the new "Internationalized Email" formatting standards should be used.
@@ -305,7 +304,7 @@ namespace MimeKit {
 		public FormatOptions ()
 		{
 			HiddenHeaders = new HashSet<HeaderId> ();
-            AdditionalMimeFilters = new List<IMimeFilter>();
+			AdditionalMimeFilters = new List<IMimeFilter>();
 			parameterEncodingMethod = ParameterEncodingMethod.Rfc2231;
 			maxLineLength = DefaultMaxLineLength;
 			allowMixedHeaderCharsets = false;
@@ -332,7 +331,7 @@ namespace MimeKit {
 			options.newLineFormat = newLineFormat;
 			options.ensureNewLine = ensureNewLine;
 			options.HiddenHeaders = new HashSet<HeaderId> (HiddenHeaders);
-            options.AdditionalMimeFilters = new List<IMimeFilter>(AdditionalMimeFilters);
+			options.AdditionalMimeFilters = new List<IMimeFilter>(AdditionalMimeFilters);
 			options.allowMixedHeaderCharsets = allowMixedHeaderCharsets;
 			options.parameterEncodingMethod = parameterEncodingMethod;
 			options.international = international;

--- a/MimeKit/HeaderList.cs
+++ b/MimeKit/HeaderList.cs
@@ -693,7 +693,7 @@ namespace MimeKit {
 
 			using (var filtered = new FilteredStream (stream)) {
 				filtered.Add (options.CreateNewLineFilter ());
-                filtered.AddRange (options.AdditionalMimeFilters);
+				filtered.AddRange (options.AdditionalMimeFilters);
 
 				foreach (var header in headers) {
 					filtered.Write (header.RawField, 0, header.RawField.Length, cancellationToken);
@@ -750,7 +750,7 @@ namespace MimeKit {
 
 			using (var filtered = new FilteredStream (stream)) {
 				filtered.Add (options.CreateNewLineFilter ());
-                filtered.AddRange (options.AdditionalMimeFilters);
+				filtered.AddRange (options.AdditionalMimeFilters);
 
 				foreach (var header in headers) {
 					await filtered.WriteAsync (header.RawField, 0, header.RawField.Length, cancellationToken).ConfigureAwait (false);

--- a/MimeKit/HeaderList.cs
+++ b/MimeKit/HeaderList.cs
@@ -693,6 +693,7 @@ namespace MimeKit {
 
 			using (var filtered = new FilteredStream (stream)) {
 				filtered.Add (options.CreateNewLineFilter ());
+                filtered.AddRange (options.AdditionalMimeFilters);
 
 				foreach (var header in headers) {
 					filtered.Write (header.RawField, 0, header.RawField.Length, cancellationToken);
@@ -749,6 +750,7 @@ namespace MimeKit {
 
 			using (var filtered = new FilteredStream (stream)) {
 				filtered.Add (options.CreateNewLineFilter ());
+                filtered.AddRange (options.AdditionalMimeFilters);
 
 				foreach (var header in headers) {
 					await filtered.WriteAsync (header.RawField, 0, header.RawField.Length, cancellationToken).ConfigureAwait (false);

--- a/MimeKit/IO/FilteredStream.cs
+++ b/MimeKit/IO/FilteredStream.cs
@@ -109,6 +109,27 @@ namespace MimeKit.IO {
 			filters.Add (filter);
 		}
 
+        /// <summary>
+        /// Adds a list of specified filters 
+        /// </summary>
+        /// <remarks>
+        /// Adds the list of <paramref name="addFilters"/> to the end of the list of filters
+        /// that data will pass through as data is read from or written to the
+        /// underlying source stream. 
+        /// </remarks>
+        /// <param name="addFilters">The list of filters. A null list or null filters within the list will be ignored.</param>
+        public void AddRange(IEnumerable<IMimeFilter> addFilters)
+        {
+            if (addFilters == null)
+                return;
+
+            foreach (var addFilter in addFilters) {
+                if (addFilter != null) {
+                    filters.Add(addFilter);
+                }
+            }
+        }
+
 		/// <summary>
 		/// Checks if the filtered stream contains the specified filter.
 		/// </summary>

--- a/MimeKit/IO/FilteredStream.cs
+++ b/MimeKit/IO/FilteredStream.cs
@@ -118,17 +118,17 @@ namespace MimeKit.IO {
         /// underlying source stream. 
         /// </remarks>
         /// <param name="addFilters">The list of filters. A null list or null filters within the list will be ignored.</param>
-        public void AddRange(IEnumerable<IMimeFilter> addFilters)
-        {
-            if (addFilters == null)
-                return;
+		public void AddRange(IEnumerable<IMimeFilter> addFilters)
+		{
+			if (addFilters == null)
+				return;
 
-            foreach (var addFilter in addFilters) {
-                if (addFilter != null) {
-                    filters.Add(addFilter);
-                }
-            }
-        }
+			foreach (var addFilter in addFilters) {
+				if (addFilter != null) {
+					filters.Add(addFilter);
+				}
+			}
+		}
 
 		/// <summary>
 		/// Checks if the filtered stream contains the specified filter.

--- a/MimeKit/MimeMessage.cs
+++ b/MimeKit/MimeMessage.cs
@@ -1085,6 +1085,7 @@ namespace MimeKit {
 			if (Body != null) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
+                    filtered.AddRange (options.AdditionalMimeFilters);
 
 					foreach (var header in MergeHeaders ()) {
 						if (options.HiddenHeaders.Contains (header.Id))
@@ -1161,6 +1162,7 @@ namespace MimeKit {
 			if (Body != null) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
+                    filtered.AddRange (options.AdditionalMimeFilters);
 
 					foreach (var header in MergeHeaders ()) {
 						if (options.HiddenHeaders.Contains (header.Id))
@@ -1580,6 +1582,7 @@ namespace MimeKit {
 						dkim = new DkimSimpleBodyFilter ();
 
 					filtered.Add (options.CreateNewLineFilter ());
+                    filtered.AddRange (options.AdditionalMimeFilters);
 					filtered.Add (dkim);
 
 					if (Body != null) {

--- a/MimeKit/MimeMessage.cs
+++ b/MimeKit/MimeMessage.cs
@@ -1085,7 +1085,7 @@ namespace MimeKit {
 			if (Body != null) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
-                    filtered.AddRange (options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 
 					foreach (var header in MergeHeaders ()) {
 						if (options.HiddenHeaders.Contains (header.Id))
@@ -1162,7 +1162,7 @@ namespace MimeKit {
 			if (Body != null) {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (options.CreateNewLineFilter ());
-                    filtered.AddRange (options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 
 					foreach (var header in MergeHeaders ()) {
 						if (options.HiddenHeaders.Contains (header.Id))
@@ -1582,7 +1582,7 @@ namespace MimeKit {
 						dkim = new DkimSimpleBodyFilter ();
 
 					filtered.Add (options.CreateNewLineFilter ());
-                    filtered.AddRange (options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 					filtered.Add (dkim);
 
 					if (Body != null) {

--- a/MimeKit/MimePart.cs
+++ b/MimeKit/MimePart.cs
@@ -588,12 +588,12 @@ namespace MimeKit {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (EncoderFilter.Create (encoding));
 
-                    if (encoding != ContentEncoding.Binary) {
-                        filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
-                        filtered.AddRange (options.AdditionalMimeFilters);
+					if (encoding != ContentEncoding.Binary) {
+						filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
+						filtered.AddRange (options.AdditionalMimeFilters);
 					}
-
-                    Content.DecodeTo (filtered, cancellationToken);
+					
+					Content.DecodeTo (filtered, cancellationToken);
 					filtered.Flush (cancellationToken);
 				}
 
@@ -614,7 +614,7 @@ namespace MimeKit {
 					// Note: if we are writing the top-level MimePart, make sure it ends with a new-line so that
 					// MimeMessage.WriteTo() *always* ends with a new-line.
 					filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
-                    filtered.AddRange (options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 					Content.WriteTo (filtered, cancellationToken);
 					filtered.Flush (cancellationToken);
 				}
@@ -666,8 +666,8 @@ namespace MimeKit {
 					filtered.Add (EncoderFilter.Create (encoding));
 
                     if (encoding != ContentEncoding.Binary) {
-                        filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
-                        filtered.AddRange (options.AdditionalMimeFilters);
+						filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
+						filtered.AddRange (options.AdditionalMimeFilters);
 					}
 
                     await Content.DecodeToAsync (filtered, cancellationToken).ConfigureAwait (false);
@@ -685,7 +685,7 @@ namespace MimeKit {
 					// Note: if we are writing the top-level MimePart, make sure it ends with a new-line so that
 					// MimeMessage.WriteTo() *always* ends with a new-line.
 					filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
-                    filtered.AddRange (options.AdditionalMimeFilters);
+					filtered.AddRange (options.AdditionalMimeFilters);
 					await Content.WriteToAsync (filtered, cancellationToken).ConfigureAwait (false);
 					await filtered.FlushAsync (cancellationToken).ConfigureAwait (false);
 				}

--- a/MimeKit/MimePart.cs
+++ b/MimeKit/MimePart.cs
@@ -588,10 +588,12 @@ namespace MimeKit {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (EncoderFilter.Create (encoding));
 
-					if (encoding != ContentEncoding.Binary)
-						filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
+                    if (encoding != ContentEncoding.Binary) {
+                        filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
+                        filtered.AddRange (options.AdditionalMimeFilters);
+					}
 
-					Content.DecodeTo (filtered, cancellationToken);
+                    Content.DecodeTo (filtered, cancellationToken);
 					filtered.Flush (cancellationToken);
 				}
 
@@ -612,6 +614,7 @@ namespace MimeKit {
 					// Note: if we are writing the top-level MimePart, make sure it ends with a new-line so that
 					// MimeMessage.WriteTo() *always* ends with a new-line.
 					filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
+                    filtered.AddRange (options.AdditionalMimeFilters);
 					Content.WriteTo (filtered, cancellationToken);
 					filtered.Flush (cancellationToken);
 				}
@@ -662,10 +665,12 @@ namespace MimeKit {
 				using (var filtered = new FilteredStream (stream)) {
 					filtered.Add (EncoderFilter.Create (encoding));
 
-					if (encoding != ContentEncoding.Binary)
-						filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
+                    if (encoding != ContentEncoding.Binary) {
+                        filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
+                        filtered.AddRange (options.AdditionalMimeFilters);
+					}
 
-					await Content.DecodeToAsync (filtered, cancellationToken).ConfigureAwait (false);
+                    await Content.DecodeToAsync (filtered, cancellationToken).ConfigureAwait (false);
 					await filtered.FlushAsync (cancellationToken).ConfigureAwait (false);
 				}
 
@@ -680,6 +685,7 @@ namespace MimeKit {
 					// Note: if we are writing the top-level MimePart, make sure it ends with a new-line so that
 					// MimeMessage.WriteTo() *always* ends with a new-line.
 					filtered.Add (options.CreateNewLineFilter (EnsureNewLine));
+                    filtered.AddRange (options.AdditionalMimeFilters);
 					await Content.WriteToAsync (filtered, cancellationToken).ConfigureAwait (false);
 					await filtered.FlushAsync (cancellationToken).ConfigureAwait (false);
 				}

--- a/MimeKit/TextPart.cs
+++ b/MimeKit/TextPart.cs
@@ -441,6 +441,7 @@ namespace MimeKit {
 				using (var filtered = new FilteredStream (memory)) {
 					filtered.Add (new CharsetFilter (encoding, CharsetUtils.UTF8));
 					filtered.Add (FormatOptions.Default.CreateNewLineFilter ());
+                    filtered.AddRange (FormatOptions.Default.AdditionalMimeFilters);
 					Content.DecodeTo (filtered);
 					filtered.Flush ();
 				}


### PR DESCRIPTION
Adds a new configuration option AdditionalMimeFilters to the FormatOptions. This can be used to filter and amend the output that gets written.

The reason behind is that we (at my company) use this to overwrite the From/To/Cc/Bcc headers (using a custom filter) to always have quoted printable names. This is because our (smarthost) mail server overrides these headers to always have quoted printable names (e.g.: =?UTF-8?Q?info?= <info@test.com>). This poses a problem because the message is signed using the normal unquoted variant, but then gets actually sent using the quoted variant. This makes the DKIM signature invalid, marking the mail as spam.

Tried several other changes (making methods public, virtual, non-static, etc). But this seems to be the least intrusive solution.