### PR TITLE
Update OpenPgpContext.cs

### DIFF
--- a/MimeKit/Cryptography/OpenPgpContext.cs
+++ b/MimeKit/Cryptography/OpenPgpContext.cs
@@ -884,7 +884,13 @@ namespace MimeKit.Cryptography {
 			throw new UnauthorizedAccessException ();
 		}
 
-		PgpSecretKey GetSecretKey (long keyId)
+
+		/// <summary>
+		/// Returns the secret key with the specified key ID
+		/// </summary>
+		/// <param name="keyId">ID of secret key to retrieve.</param>
+		/// <returns></returns>
+		public virtual PgpSecretKey GetSecretKey (long keyId)
 		{
 			foreach (var key in EnumerateSecretKeys ()) {
 				if (key.KeyId == keyId)


### PR DESCRIPTION
Howdy mate, I had to make the `GetSecretKey` method public and virtual. My reasons is that in order to lookup secret key(s) from a database (for instance, non GnuPG file system), it was necessary.

The reasons are that the default implementation of `GetSecretKey`, which is used when decrypting a `MultipartEncrypted`, it will invoke `EnumerateSecretKeys`, which obviously doesn't make much sense when you might have millions of keys. Hence, I realised if I made `GetSecretKey` **public and virtual**, I could use the `keyId` to lookup a specific key from my database, completely ignoring the entire idea of enumerating all keys.

Not sure if I am missing something here, but I think this is what's necessary in order to create my completely custom (database based) key storage ...

Hopefully you're ok with this :)