### PR TITLE
Include WindowsSecureMimeContext in .NET Standard 2.x build

### DIFF
--- a/MimeKit/MimeKit.csproj
+++ b/MimeKit/MimeKit.csproj
@@ -56,6 +56,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2.')) ">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.7.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
   </ItemGroup>
 
@@ -133,9 +134,9 @@
     <Compile Include="Cryptography\SqliteCertificateDatabase.cs" />
     <Compile Include="Cryptography\SubjectIdentifierType.cs" />
     <Compile Include="Cryptography\TemporarySecureMimeContext.cs" />
-    <Compile Include="Cryptography\WindowsSecureMimeContext.cs" Condition="$(TargetFramework.StartsWith('net4'))" />
-    <Compile Include="Cryptography\WindowsSecureMimeDigitalCertificate.cs" Condition="$(TargetFramework.StartsWith('net4'))" />
-    <Compile Include="Cryptography\WindowsSecureMimeDigitalSignature.cs" Condition="$(TargetFramework.StartsWith('net4'))" />
+    <Compile Include="Cryptography\WindowsSecureMimeContext.cs" Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.'))" />
+    <Compile Include="Cryptography\WindowsSecureMimeDigitalCertificate.cs" Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.'))" />
+    <Compile Include="Cryptography\WindowsSecureMimeDigitalSignature.cs" Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.'))" />
     <Compile Include="Cryptography\X509Certificate2Extensions.cs" Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.'))" />
     <Compile Include="Cryptography\X509CertificateChain.cs" />
     <Compile Include="Cryptography\X509CertificateDatabase.cs" />


### PR DESCRIPTION
Using the `System.Security.Cryptography.Pkcs` package, the `WindowsSecureMimeContext` and related classes can be used together with .NET Standard. This PR changes the csproj-File for MimeKit, including these classes and the package into the build for .NET Standard 2.0.

There might be some limitations when using this context on Linux / OS X, as the underlying `X509Store` used for storing / receiving [has some limitations](https://docs.microsoft.com/en-US/dotnet/standard/security/cross-platform-cryptography#x509store). However, at least for my use case (verifying / signing via S/MIME using the OS root certificates; as well as importing certs into the store and using them for en-/decryption), this works fine (using Debian Buster and Ubuntu Focal). 

We maybe should add a note concerning this into the docs, but I'd like to hear your thoughts on this first.