### PR TITLE
Include message-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ var message = new MimeMessage ();
 message.From.Add (new MailboxAddress ("Joey", "joey@friends.com"));
 message.To.Add (new MailboxAddress ("Alice", "alice@wonderland.com"));
 message.Subject = "How you doin?";
+message.MessageId = MimeKit.Utils.MimeUtils.GenerateMessageId();
 
 message.Body = new TextPart ("plain") {
     Text = @"Hey Alice,
@@ -396,6 +397,8 @@ specifies the media-subtype, in this case, "plain". Another media subtype you ar
 is the "html" subtype. Some other examples include "enriched", "rtf", and "csv".
 
 The `Text` property is the easiest way to both get and set the string content of the MIME part.
+
+Although the 'MessageId' property is optional, every message SHOULD have a "Message-ID:" field. Without it DKIM validation can fail.
 
 ### Creating a Message with Attachments
 


### PR DESCRIPTION
 RFC 2822 as "optional" (although it says that it should be present):

Though optional, every message SHOULD have a "Message-ID:" field.

As per my bitter experience with my ISP, and just finding this post in SO: https://stackoverflow.com/questions/57837395/dkim-fails-when-sending-mails-with-smtplib

Adding a Message-Id ensured that my DKIM signature was valid and all my emails did not end up in Junk.

If this PR is accepted I'll also update some other samples with message-Id.