### PR TITLE
Don't allocate when adding attachments.

### DIFF
--- a/MimeKit/AttachmentCollection.cs
+++ b/MimeKit/AttachmentCollection.cs
@@ -135,7 +135,7 @@ namespace MimeKit {
 
 			if (attachment.ContentType.IsMimeType ("text", "*")) {
 				var filter = new BestEncodingFilter ();
-				int bufLength = 4096;
+				const int BufLength = 4096;
 				var buf = ArrayPool<byte>.Shared.Rent (bufLength);
 				int index, length;
 				int nread;

--- a/MimeKit/AttachmentCollection.cs
+++ b/MimeKit/AttachmentCollection.cs
@@ -26,12 +26,12 @@
 
 using System;
 using System.IO;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 
 using MimeKit.IO;
 using MimeKit.IO.Filters;
-using System.Buffers;
 
 namespace MimeKit {
 	/// <summary>

--- a/MimeKit/MimeKit.csproj
+++ b/MimeKit/MimeKit.csproj
@@ -66,6 +66,10 @@
     <Reference Include="System.Security" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="Cryptography\ApplicationPgpEncrypted.cs" />


### PR DESCRIPTION
Hi, I don't know if you're looking for this kind of PR but I spotted the allocation when F12ing through the methods in Visual Studio.

A quick search for `new byte[` indicates that there are quite a few places in the library where the same pattern could be used e.g. `FilteredStream.Read`. Unfortunately I cannot currently dedicate the time to replace each instance so I thought I would introduce an example fix for this instance.