### PR TITLE
Proposal to surface internal method GetMessageRecipients

### DIFF
--- a/MimeKit/MimeMessage.cs
+++ b/MimeKit/MimeMessage.cs
@@ -1705,7 +1705,11 @@ namespace MimeKit {
 			return null;
 		}
 
-		IList<MailboxAddress> GetMessageRecipients (bool includeSenders)
+		/// <summary>
+		/// Gets all addresses in the message, which will be sent to
+		/// </summary>
+		/// <param name="includeSenders">Whether to include sender headers</param>
+		public IList<MailboxAddress> GetMessageRecipients (bool includeSenders)
 		{
 			var recipients = new HashSet<MailboxAddress> ();
 


### PR DESCRIPTION
I'd like to propose making the method `GetMessageRecipients` public, to improve developer ergonomics in a particular scenario.

#### Use case

We need to be able to control the specific address given in the `MAIL FROM` command. To do this, MailKit offers a signature of `SmtpClient.Send(` which lets us specify a `sender` MailBoxAddress. However, these methods on `SmtpClient` _also_ require a list of recipients to be included. To get this list, we need to go back to our finished `MimeMessage` that we already composed, and determine who's on the To/CC/BCC/etc list; effectively mimicking what `GetMessageRecipients` already does. Making this existing method public feels like it might be of value to others in this situation.

Pseudo-code of what we already do:

```
public void SendAMessage(MimeMessage msg)
{
     var mailFromAddress = new MailBoxAddress("ourspecialaddress@example.com");
    _smtpClient.Send(msg, mailFromAddress, GetRecipientsFromMessage(msg));
}

public void GetRecipientsFromMessage(MimeMessage msg)
{
    // duplicating what's already in MimeKit
   return msg.To + msg.CC + msg.Bcc etc...
}

```

Alternatively, perhaps you would consider a PR which added an additional implementation of `Send` which only took FormatOptions/MimeMessage/Sendermailbox, and did this process implicitly? I appreciate this likely bloats MailTransport more than you'd want, though.