### PR TITLE
Improve Code Quality 2

### DIFF
--- a/MimeKit/ContentType.cs
+++ b/MimeKit/ContentType.cs
@@ -280,8 +280,8 @@ namespace MimeKit {
 			if (mediaSubtype == null)
 				throw new ArgumentNullException (nameof (mediaSubtype));
 
-			if (mediaType == "*" || mediaType.Equals (type, StringComparison.OrdinalIgnoreCase))
-				return mediaSubtype == "*" || mediaSubtype.Equals (subtype, StringComparison.OrdinalIgnoreCase);
+			if (mediaType is "*" || mediaType.Equals (type, StringComparison.OrdinalIgnoreCase))
+				return mediaSubtype is "*" || mediaSubtype.Equals (subtype, StringComparison.OrdinalIgnoreCase);
 
 			return false;
 		}

--- a/MimeKit/Cryptography/ArcSigner.cs
+++ b/MimeKit/Cryptography/ArcSigner.cs
@@ -415,7 +415,7 @@ namespace MimeKit.Cryptography {
 				if (ArcShouldNotInclude.Contains (fields[i]))
 					throw new ArgumentException (string.Format ("The list of headers to sign SHOULD NOT include the '{0}' header.", headers[i]), nameof (headers));
 
-				if (fields[i] == "from")
+				if (fields[i] is "from")
 					containsFrom = true;
 			}
 

--- a/MimeKit/Cryptography/AuthenticationResults.cs
+++ b/MimeKit/Cryptography/AuthenticationResults.cs
@@ -486,7 +486,7 @@ namespace MimeKit.Cryptography {
 
 				value = Encoding.ASCII.GetString (text, tokenIndex, index - tokenIndex);
 
-				if (value == "reason" || value == "action") {
+				if (value is "reason" or "action") {
 					if (!ParseUtils.SkipCommentsAndWhiteSpace (text, ref index, endIndex, throwOnError))
 						return false;
 
@@ -523,7 +523,7 @@ namespace MimeKit.Cryptography {
 					if (quoted)
 						reason = MimeUtils.Unquote (reason);
 
-					if (value == "action")
+					if (value is "action")
 						resinfo.Action = reason;
 					else
 						resinfo.Reason = reason;

--- a/MimeKit/Cryptography/DkimPublicKeyLocatorBase.cs
+++ b/MimeKit/Cryptography/DkimPublicKeyLocatorBase.cs
@@ -118,7 +118,7 @@ namespace MimeKit.Cryptography {
 			}
 
 			if (p != null) {
-				if (k == "ed25519") {
+				if (k is "ed25519") {
 					var decoded = Convert.FromBase64String (p);
 
 					return new Ed25519PublicKeyParameters (decoded, 0);

--- a/MimeKit/Cryptography/DkimSigner.cs
+++ b/MimeKit/Cryptography/DkimSigner.cs
@@ -358,7 +358,7 @@ namespace MimeKit.Cryptography {
 				if (DkimShouldNotInclude.Contains (fields[i]))
 					throw new ArgumentException (string.Format ("The list of headers to sign SHOULD NOT include the '{0}' header.", headers[i]), nameof (headers));
 
-				if (fields[i] == "from")
+				if (fields[i] is "from")
 					containsFrom = true;
 			}
 

--- a/MimeKit/Cryptography/OpenPgpContext.cs
+++ b/MimeKit/Cryptography/OpenPgpContext.cs
@@ -648,13 +648,13 @@ namespace MimeKit.Cryptography {
 				return null;
 
 			var scheme = keyServer.Scheme.ToLowerInvariant ();
-			var builder = new UriBuilder ();
-
-			builder.Scheme = scheme == "hkp" ? "http" : scheme;
-			builder.Host = keyServer.Host;
+			var builder = new UriBuilder {
+				Scheme = scheme is "hkp" ? "http" : scheme,
+				Host = keyServer.Host
+			};
 
 			if (keyServer.IsDefaultPort) {
-				if (scheme == "hkp")
+				if (scheme is "hkp")
 					builder.Port = 11371;
 			} else {
 				builder.Port = keyServer.Port;
@@ -1059,20 +1059,20 @@ namespace MimeKit.Cryptography {
 		/// </exception>
 		public static DigestAlgorithm GetDigestAlgorithm (HashAlgorithmTag hashAlgorithm)
 		{
-			switch (hashAlgorithm) {
-			case HashAlgorithmTag.MD5: return DigestAlgorithm.MD5;
-			case HashAlgorithmTag.Sha1: return DigestAlgorithm.Sha1;
-			case HashAlgorithmTag.RipeMD160: return DigestAlgorithm.RipeMD160;
-			case HashAlgorithmTag.DoubleSha: return DigestAlgorithm.DoubleSha;
-			case HashAlgorithmTag.MD2: return DigestAlgorithm.MD2;
-			case HashAlgorithmTag.Tiger192: return DigestAlgorithm.Tiger192;
-			case HashAlgorithmTag.Haval5pass160: return DigestAlgorithm.Haval5160;
-			case HashAlgorithmTag.Sha256: return DigestAlgorithm.Sha256;
-			case HashAlgorithmTag.Sha384: return DigestAlgorithm.Sha384;
-			case HashAlgorithmTag.Sha512: return DigestAlgorithm.Sha512;
-			case HashAlgorithmTag.Sha224: return DigestAlgorithm.Sha224;
-			default: throw new ArgumentOutOfRangeException (nameof (hashAlgorithm));
-			}
+			return hashAlgorithm switch {
+				HashAlgorithmTag.MD5 => DigestAlgorithm.MD5,
+				HashAlgorithmTag.Sha1 => DigestAlgorithm.Sha1,
+				HashAlgorithmTag.RipeMD160 => DigestAlgorithm.RipeMD160,
+				HashAlgorithmTag.DoubleSha => DigestAlgorithm.DoubleSha,
+				HashAlgorithmTag.MD2 => DigestAlgorithm.MD2,
+				HashAlgorithmTag.Tiger192 => DigestAlgorithm.Tiger192,
+				HashAlgorithmTag.Haval5pass160 => DigestAlgorithm.Haval5160,
+				HashAlgorithmTag.Sha256 => DigestAlgorithm.Sha256,
+				HashAlgorithmTag.Sha384 => DigestAlgorithm.Sha384,
+				HashAlgorithmTag.Sha512 => DigestAlgorithm.Sha512,
+				HashAlgorithmTag.Sha224 => DigestAlgorithm.Sha224,
+				_ => throw new ArgumentOutOfRangeException (nameof (hashAlgorithm))
+			};
 		}
 
 		/// <summary>
@@ -1093,18 +1093,18 @@ namespace MimeKit.Cryptography {
 		/// </exception>
 		public static PublicKeyAlgorithm GetPublicKeyAlgorithm (PublicKeyAlgorithmTag algorithm)
 		{
-			switch (algorithm) {
-			case PublicKeyAlgorithmTag.RsaGeneral: return PublicKeyAlgorithm.RsaGeneral;
-			case PublicKeyAlgorithmTag.RsaEncrypt: return PublicKeyAlgorithm.RsaEncrypt;
-			case PublicKeyAlgorithmTag.RsaSign: return PublicKeyAlgorithm.RsaSign;
-			case PublicKeyAlgorithmTag.ElGamalGeneral: return PublicKeyAlgorithm.ElGamalGeneral;
-			case PublicKeyAlgorithmTag.ElGamalEncrypt: return PublicKeyAlgorithm.ElGamalEncrypt;
-			case PublicKeyAlgorithmTag.Dsa: return PublicKeyAlgorithm.Dsa;
-			case PublicKeyAlgorithmTag.ECDH: return PublicKeyAlgorithm.EllipticCurve;
-			case PublicKeyAlgorithmTag.ECDsa: return PublicKeyAlgorithm.EllipticCurveDsa;
-			case PublicKeyAlgorithmTag.DiffieHellman: return PublicKeyAlgorithm.DiffieHellman;
-			default: throw new ArgumentOutOfRangeException (nameof (algorithm));
-			}
+			return algorithm switch {
+				PublicKeyAlgorithmTag.RsaGeneral => PublicKeyAlgorithm.RsaGeneral,
+				PublicKeyAlgorithmTag.RsaEncrypt => PublicKeyAlgorithm.RsaEncrypt,
+				PublicKeyAlgorithmTag.RsaSign => PublicKeyAlgorithm.RsaSign,
+				PublicKeyAlgorithmTag.ElGamalGeneral => PublicKeyAlgorithm.ElGamalGeneral,
+				PublicKeyAlgorithmTag.ElGamalEncrypt => PublicKeyAlgorithm.ElGamalEncrypt,
+				PublicKeyAlgorithmTag.Dsa => PublicKeyAlgorithm.Dsa,
+				PublicKeyAlgorithmTag.ECDH => PublicKeyAlgorithm.EllipticCurve,
+				PublicKeyAlgorithmTag.ECDsa => PublicKeyAlgorithm.EllipticCurveDsa,
+				PublicKeyAlgorithmTag.DiffieHellman => PublicKeyAlgorithm.DiffieHellman,
+				_ => throw new ArgumentOutOfRangeException (nameof (algorithm))
+			};
 		}
 
 		static bool TryGetPublicKey (PgpPublicKeyRing keyring, long keyId, out PgpPublicKey pubkey)

--- a/MimeKit/Cryptography/SQLServerCertificateDatabase.cs
+++ b/MimeKit/Cryptography/SQLServerCertificateDatabase.cs
@@ -298,7 +298,7 @@ namespace MimeKit.Cryptography {
 				if (value is DateTime dateTime && dateTime < DateUtils.UnixEpoch)
 					value = DateUtils.UnixEpoch;
 
-				if (columns[i].ColumnName == "PRIVATEKEY" && value is DBNull) {
+				if (columns[i].ColumnName is "PRIVATEKEY" && value is DBNull) {
 #if NET46_OR_GREATER || NET5_0_OR_GREATER || NETSTANDARD
 					value = Array.Empty<byte> ();
 #else

--- a/MimeKit/Cryptography/SqlCertificateDatabase.cs
+++ b/MimeKit/Cryptography/SqlCertificateDatabase.cs
@@ -254,7 +254,7 @@ namespace MimeKit.Cryptography {
 			bool hasAnchorColumn = false;
 
 			for (int i = 0; i < currentColumns.Count; i++) {
-				if (currentColumns[i].ColumnName.Equals ("ANCHOR", StringComparison.Ordinal)) {
+				if (currentColumns[i].ColumnName is "ANCHOR") {
 					hasAnchorColumn = true;
 					break;
 				}

--- a/MimeKit/Cryptography/X509Certificate2Extensions.cs
+++ b/MimeKit/Cryptography/X509Certificate2Extensions.cs
@@ -87,13 +87,13 @@ namespace MimeKit.Cryptography
 			var identifier = certificate.GetKeyAlgorithm ();
 			var oid = new Oid (identifier);
 
-			switch (oid.FriendlyName) {
-			case "DSA": return PublicKeyAlgorithm.Dsa;
-			case "RSA": return PublicKeyAlgorithm.RsaGeneral;
-			case "ECC": return PublicKeyAlgorithm.EllipticCurve;
-			case "DH": return PublicKeyAlgorithm.DiffieHellman;
-			default: return PublicKeyAlgorithm.None;
-			}
+			return oid.FriendlyName switch {
+				"DSA" => PublicKeyAlgorithm.Dsa,
+				"RSA" => PublicKeyAlgorithm.RsaGeneral,
+				"ECC" => PublicKeyAlgorithm.EllipticCurve,
+				"DH"  => PublicKeyAlgorithm.DiffieHellman,
+				_     => PublicKeyAlgorithm.None
+			};
 		}
 
 		static EncryptionAlgorithm[] DecodeEncryptionAlgorithms (byte[] rawData)
@@ -138,7 +138,7 @@ namespace MimeKit.Cryptography
 				throw new ArgumentNullException (nameof (certificate));
 
 			foreach (var extension in certificate.Extensions) {
-				if (extension.Oid.Value == "1.2.840.113549.1.9.15") {
+				if (extension.Oid.Value is "1.2.840.113549.1.9.15") {
 					var algorithms = DecodeEncryptionAlgorithms (extension.RawData);
 
 					if (algorithms != null)

--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -827,7 +827,7 @@ namespace MimeKit {
 					index++;
 				}
 
-				if (lineLength + token.Length + 1 > format.MaxLineLength || name == "bh" || name == "b") {
+				if (lineLength + token.Length + 1 > format.MaxLineLength || name is "bh" or "b") {
 					encoded.Append (format.NewLine);
 					encoded.Append ('\t');
 					lineLength = 1;

--- a/MimeKit/MimeKit.csproj
+++ b/MimeKit/MimeKit.csproj
@@ -6,6 +6,7 @@
     <VersionPrefix>3.1.1</VersionPrefix>
     <Authors>Jeffrey Stedfast</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net452;net46;net47;net48;net5.0;net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AssemblyName>MimeKit</AssemblyName>

--- a/MimeKit/MimeKitLite.csproj
+++ b/MimeKit/MimeKitLite.csproj
@@ -6,6 +6,7 @@
     <VersionPrefix>3.1.1</VersionPrefix>
     <Authors>Jeffrey Stedfast</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net452;net46;net47;net48;net5.0;net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AssemblyName>MimeKitLite</AssemblyName>

--- a/MimeKit/MultipartAlternative.cs
+++ b/MimeKit/MultipartAlternative.cs
@@ -149,7 +149,7 @@ namespace MimeKit {
 				var converter = new FlowedToText ();
 
 				if (text.ContentType.Parameters.TryGetValue ("delsp", out string delsp))
-					converter.DeleteSpace = delsp.ToLowerInvariant () == "yes";
+					converter.DeleteSpace = string.Equals(delsp, "yes", StringComparison.OrdinalIgnoreCase);
 
 				return converter.Convert (text.Text);
 			}

--- a/MimeKit/MultipartRelated.cs
+++ b/MimeKit/MultipartRelated.cs
@@ -263,7 +263,7 @@ namespace MimeKit {
 
 			CheckDisposed ();
 
-			bool cid = uri.IsAbsoluteUri && uri.Scheme.ToLowerInvariant () == "cid";
+			bool cid = uri.IsAbsoluteUri && string.Equals(uri.Scheme, "cid", StringComparison.OrdinalIgnoreCase);
 
 			for (int index = 0; index < Count; index++) {
 				var entity = this[index];

--- a/MimeKit/Parameter.cs
+++ b/MimeKit/Parameter.cs
@@ -406,11 +406,11 @@ namespace MimeKit {
 				}
 			}
 
-			switch (encoding) {
-			case 0: return Encoding.ASCII;
-			case 1: return Encoding.GetEncoding (28591); // iso-8859-1
-			default: return defaultEncoding;
-			}
+			return encoding switch {
+				0 => Encoding.ASCII,
+				1 => Encoding.GetEncoding (28591), // iso-8859-1
+				_ => defaultEncoding
+			};
 		}
 
 		static bool Rfc2231GetNextValue (FormatOptions options, string charset, Encoder encoder, HexEncoder hex, char[] chars, ref int index, ref byte[] bytes, ref byte[] encoded, int maxLength, out string value)
@@ -449,7 +449,7 @@ namespace MimeKit {
 				count = encoder.GetBytes (chars, index, length, bytes, 0, true);
 
 				// Note: the first chunk needs to be encoded in order to declare the charset
-				if (index > 0 || charset == "us-ascii") {
+				if (index > 0 || charset is "us-ascii") {
 					var method = GetEncodeMethod (bytes, count);
 
 					if (method == EncodeMethod.Quote) {

--- a/MimeKit/ParserOptions.cs
+++ b/MimeKit/ParserOptions.cs
@@ -268,14 +268,10 @@ namespace MimeKit {
 
 		internal static bool IsEncoded (ContentEncoding encoding)
 		{
-			switch (encoding) {
-			case ContentEncoding.SevenBit:
-			case ContentEncoding.EightBit:
-			case ContentEncoding.Binary:
-				return false;
-			default:
-				return true;
-			}
+			return encoding switch {
+				ContentEncoding.SevenBit or ContentEncoding.EightBit or ContentEncoding.Binary => false,
+				_ => true
+			};			
 		}
 
 		static bool IsEncoded (IList<Header> headers)
@@ -321,7 +317,7 @@ namespace MimeKit {
 			// as well, but since MessageDispositionNotification is a MImePart subclass rather than a
 			// MessagePart subclass, it means that the content won't be parsed until later and so we can
 			// actually handle that w/o any problems.
-			if (type == "message") {
+			if (type is "message") {
 				switch (subtype) {
 				case "global-disposition-notification":
 				case "disposition-notification":
@@ -348,7 +344,7 @@ namespace MimeKit {
 				}
 			}
 
-			if (type == "multipart") {
+			if (type is "multipart") {
 				switch (subtype) {
 				case "alternative":
 					return new MultipartAlternative (args);
@@ -367,7 +363,7 @@ namespace MimeKit {
 				}
 			}
 
-			if (type == "application") {
+			if (type is "application") {
 				switch (subtype) {
 #if ENABLE_CRYPTO
 				case "x-pkcs7-signature":
@@ -391,8 +387,8 @@ namespace MimeKit {
 				}
 			}
 
-			if (type == "text") {
-				if (subtype == "rfc822-headers" && !IsEncoded (headers))
+			if (type is "text") {
+				if (subtype is "rfc822-headers" && !IsEncoded (headers))
 					return new TextRfc822Headers (args);
 
 				return new TextPart (args);


### PR DESCRIPTION
- Enables C# 10
-  Use is when comparing strings exactly (improving codegen)
- Eliminates two string allocations
- Uses switch expressions
