### PR TITLE
Reduce Allocations

### DIFF
--- a/MimeKit/Cryptography/X509CertificateDatabase.cs
+++ b/MimeKit/Cryptography/X509CertificateDatabase.cs
@@ -40,6 +40,7 @@ using Org.BouncyCastle.Asn1.BC;
 using Org.BouncyCastle.Asn1.Pkcs;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.X509.Store;
+using MimeKit.Utils;
 
 namespace MimeKit.Cryptography {
 	/// <summary>
@@ -283,8 +284,12 @@ namespace MimeKit.Cryptography {
 			var algorithms = new List<EncryptionAlgorithm> ();
 			var values = reader.GetString (column);
 
-			foreach (var token in values.Split (new [] { ',' }, StringSplitOptions.RemoveEmptyEntries)) {
-				if (Enum.TryParse (token.Trim (), true, out EncryptionAlgorithm algorithm))
+			var splitter = new Splitter (values.AsSpan(), ',');
+
+			while (splitter.TryReadNext(out var token)) {
+				if (token.IsEmpty) continue;
+
+				if (Enum.TryParse (token.Trim ().ToString(), true, out EncryptionAlgorithm algorithm))
 					algorithms.Add (algorithm);
 			}
 

--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -744,7 +744,7 @@ namespace MimeKit {
 			return encoding.GetBytes (encoded.ToString ());
 		}
 
-		static void EncodeDkimLongValue (FormatOptions format, StringBuilder encoded, ref int lineLength, string value)
+		static void EncodeDkimLongValue (FormatOptions format, StringBuilder encoded, ref int lineLength, ReadOnlySpan<char> value)
 		{
 			int startIndex = 0;
 
@@ -752,7 +752,7 @@ namespace MimeKit {
 				int lineLeft = format.MaxLineLength - lineLength;
 				int index = Math.Min (startIndex + lineLeft, value.Length);
 
-				encoded.Append (value.AsSpan (startIndex, index - startIndex));
+				encoded.Append (value.Slice (startIndex, index - startIndex));
 				lineLength += (index - startIndex);
 
 				if (index == value.Length)
@@ -766,31 +766,34 @@ namespace MimeKit {
 			} while (true);
 		}
 
-		static void EncodeDkimHeaderList (FormatOptions format, StringBuilder encoded, ref int lineLength, string value, char delim)
+		static void EncodeDkimHeaderList (FormatOptions format, StringBuilder encoded, ref int lineLength, ReadOnlySpan<char> value, char delim)
 		{
-			var tokens = value.Split (delim);
+			var splitter = new Splitter (value, delim);
+			int i = 0;
 
-			for (int i = 0; i < tokens.Length; i++) {
+			while (splitter.TryReadNext(out var item)) {
 				if (i > 0) {
 					encoded.Append (delim);
 					lineLength++;
 				}
 
-				if (lineLength + tokens[i].Length + 1 > format.MaxLineLength) {
+				if (lineLength + item.Length + 1 > format.MaxLineLength) {
 					encoded.Append (format.NewLine);
 					encoded.Append ('\t');
 					lineLength = 1;
 
-					if (tokens[i].Length + 1 > format.MaxLineLength) {
-						EncodeDkimLongValue (format, encoded, ref lineLength, tokens[i]);
+					if (item.Length + 1 > format.MaxLineLength) {
+						EncodeDkimLongValue (format, encoded, ref lineLength, item);
 					} else {
-						lineLength += tokens[i].Length;
-						encoded.Append (tokens[i]);
+						lineLength += item.Length;
+						encoded.Append (item);
 					}
 				} else {
-					lineLength += tokens[i].Length;
-					encoded.Append (tokens[i]);
+					lineLength += item.Length;
+					encoded.Append (item);
 				}
+
+				i++;
 			}
 		}
 
@@ -839,13 +842,13 @@ namespace MimeKit {
 				if (token.Length > format.MaxLineLength) {
 					switch (name) {
 					case "z":
-						EncodeDkimHeaderList (format, encoded, ref lineLength, token.ToString (), '|');
+						EncodeDkimHeaderList (format, encoded, ref lineLength, token.ToString ().AsSpan(), '|');
 						break;
 					case "h":
-						EncodeDkimHeaderList (format, encoded, ref lineLength, token.ToString (), ':');
+						EncodeDkimHeaderList (format, encoded, ref lineLength, token.ToString ().AsSpan (), ':');
 						break;
 					default:
-						EncodeDkimLongValue (format, encoded, ref lineLength, token.ToString ());
+						EncodeDkimLongValue (format, encoded, ref lineLength, token.ToString ().AsSpan ());
 						break;
 					}
 				} else {

--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -849,7 +849,7 @@ namespace MimeKit {
 						break;
 					}
 				} else {
-					encoded.Append (token.ToString ());
+					encoded.Append (token);
 					lineLength += token.Length;
 				}
 

--- a/MimeKit/MimeKit.csproj
+++ b/MimeKit/MimeKit.csproj
@@ -250,6 +250,7 @@
     <Compile Include="Tnef\TnefReader.cs" />
     <Compile Include="Tnef\TnefReaderStream.cs" />
     <Compile Include="Utils\BufferPool.cs" />
+    <Compile Include="Utils\Splitter.cs" />
     <Compile Include="Utils\ByteExtensions.cs" />
     <Compile Include="Utils\CharsetUtils.cs" />
     <Compile Include="Utils\Crc32.cs" />

--- a/MimeKit/Utils/MimeUtils.cs
+++ b/MimeKit/Utils/MimeUtils.cs
@@ -400,13 +400,13 @@ namespace MimeKit.Utils {
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
 
-			builder.Append ("\"");
+			builder.Append ('"');
 			for (int i = 0; i < text.Length; i++) {
 				if (text[i] == '\\' || text[i] == '"')
 					builder.Append ('\\');
 				builder.Append (text[i]);
 			}
-			builder.Append ("\"");
+			builder.Append ('"');
 
 			return builder;
 		}

--- a/MimeKit/Utils/Splitter.cs
+++ b/MimeKit/Utils/Splitter.cs
@@ -1,0 +1,69 @@
+﻿//
+// Splitter.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2022 .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+
+namespace MimeKit.Utils
+{
+	internal ref struct Splitter
+	{
+		private readonly ReadOnlySpan<char> text;
+		private readonly char seperator;
+		private int position;
+
+		public Splitter (ReadOnlySpan<char> text, char seperator) {
+			this.text = text;
+			this.seperator = seperator;
+			this.position = 0;
+		}
+
+		public bool TryReadNext (out ReadOnlySpan<char> item)
+		{
+			if (IsEof) {
+				item = default;
+				return false;
+			}
+
+			int start = position;
+
+			int seperatorIndex = text.Slice(position).IndexOf (seperator);
+
+			if (seperatorIndex > -1) {
+				position += seperatorIndex + 1;
+
+				item = text.Slice (start, seperatorIndex);
+			} else {
+				position = text.Length;
+
+				item = text.Slice(start);
+			}
+
+			return true;
+		}
+
+		public bool IsEof => position == text.Length;
+	}
+}

--- a/MimeKit/Utils/StringBuilderExtensions.cs
+++ b/MimeKit/Utils/StringBuilderExtensions.cs
@@ -139,6 +139,11 @@ namespace MimeKit.Utils {
 				System.Buffers.ArrayPool<char>.Shared.Return (buffer);
 			}
 		}
+
+		public static void Append (this StringBuilder text, StringBuilder value)
+		{
+			text.Append (value.ToString ());
+		}
 #endif
 
 #if DEBUG


### PR DESCRIPTION
- Introduces and uses a StringBuilder.Append(StringBuilder) polyfill to eliminate an allocation
- Introduces a custom splitter to eliminate a few array allocations (and suballocations)
- Refactors the header tokenizer to eliminate allocations (looks like we both jumped on this -- and I need to rebase)