### PR TITLE
Introduce ValueStringBuilder

### DIFF
--- a/MimeKit/Cryptography/AuthenticationResults.cs
+++ b/MimeKit/Cryptography/AuthenticationResults.cs
@@ -1155,7 +1155,7 @@ namespace MimeKit.Cryptography {
 		/// <returns>The serialized string.</returns>
 		public override string ToString ()
 		{
-			var builder = new StringBuilder ();
+			var builder = new ValueStringBuilder (128);
 
 			if (Office365AuthenticationServiceIdentifier != null) {
 				builder.Append (Office365AuthenticationServiceIdentifier);
@@ -1180,15 +1180,15 @@ namespace MimeKit.Cryptography {
 
 			if (!string.IsNullOrEmpty (Reason)) {
 				builder.Append (" reason=");
-				MimeUtils.AppendQuoted (builder, Reason);
+				MimeUtils.AppendQuoted (ref builder, Reason);
 			} else if (!string.IsNullOrEmpty (Action)) {
 				builder.Append (" action=");
-				MimeUtils.AppendQuoted (builder, Action);
+				MimeUtils.AppendQuoted (ref builder, Action);
 			}
 
 			for (int i = 0; i < Properties.Count; i++) {
 				builder.Append (' ');
-				builder.Append (Properties[i]);
+				builder.Append (Properties[i].ToString());
 			}
 
 			return builder.ToString ();

--- a/MimeKit/Cryptography/AuthenticationResults.cs
+++ b/MimeKit/Cryptography/AuthenticationResults.cs
@@ -189,10 +189,13 @@ namespace MimeKit.Cryptography {
 		/// <returns>The serialized string.</returns>
 		public override string ToString ()
 		{
-			var builder = new StringBuilder ();
+			var builder = new ValueStringBuilder (256);
 
-			if (Instance.HasValue)
-				builder.AppendFormat ("i={0}; ", Instance.Value.ToString (CultureInfo.InvariantCulture));
+			if (Instance.HasValue) {
+				builder.Append ("i=");
+				builder.Append(Instance.Value.ToString (CultureInfo.InvariantCulture));
+				builder.Append ("; ");
+			}
 
 			if (AuthenticationServiceIdentifier != null) {
 				builder.Append (AuthenticationServiceIdentifier);
@@ -209,7 +212,7 @@ namespace MimeKit.Cryptography {
 				for (int i = 0; i < Results.Count; i++) {
 					if (i > 0)
 						builder.Append ("; ");
-					builder.Append (Results[i]);
+					builder.Append (Results[i].ToString());
 				}
 			} else {
 				builder.Append ("none");

--- a/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
+++ b/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
@@ -192,7 +192,7 @@ namespace MimeKit.Cryptography {
 
 		internal static string AsHex (this byte[] blob)
 		{
-			var hex = new StringBuilder (blob.Length * 2);
+			var hex = new ValueStringBuilder (blob.Length * 2);
 
 			for (int i = 0; i < blob.Length; i++)
 				hex.Append (blob[i].ToString ("x2"));

--- a/MimeKit/Cryptography/OpenPgpContext.cs
+++ b/MimeKit/Cryptography/OpenPgpContext.cs
@@ -502,7 +502,7 @@ namespace MimeKit.Cryptography {
 		/// <returns>A string representing the hex-encoded data.</returns>
 		static string HexEncode (byte[] data)
 		{
-			var fingerprint = new StringBuilder ();
+			var fingerprint = new ValueStringBuilder (data.Length * 2);
 
 			for (int i = 0; i < data.Length; i++)
 				fingerprint.Append (data[i].ToString ("x2"));

--- a/MimeKit/Cryptography/OpenPgpDigitalCertificate.cs
+++ b/MimeKit/Cryptography/OpenPgpDigitalCertificate.cs
@@ -41,7 +41,7 @@ namespace MimeKit.Cryptography {
 		internal OpenPgpDigitalCertificate (PgpPublicKeyRing keyring, PgpPublicKey pubkey)
 		{
 			var bytes = pubkey.GetFingerprint ();
-			var builder = new StringBuilder ();
+			var builder = new ValueStringBuilder (bytes.Length * 2);
 
 			for (int i = 0; i < bytes.Length; i++)
 				builder.Append (bytes[i].ToString ("X2"));

--- a/MimeKit/DomainList.cs
+++ b/MimeKit/DomainList.cs
@@ -318,7 +318,7 @@ namespace MimeKit {
 
 		internal string Encode (FormatOptions options)
 		{
-			var builder = new StringBuilder ();
+			var builder = new ValueStringBuilder (256);
 
 			for (int i = 0; i < domains.Count; i++) {
 				if (string.IsNullOrWhiteSpace (domains[i]))
@@ -351,7 +351,7 @@ namespace MimeKit {
 		/// <returns>A string representing the <see cref="DomainList"/>.</returns>
 		public override string ToString ()
 		{
-			var builder = new StringBuilder ();
+			var builder = new ValueStringBuilder ();
 
 			for (int i = 0; i < domains.Count; i++) {
 				if (string.IsNullOrWhiteSpace (domains[i]))

--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -531,11 +531,11 @@ namespace MimeKit {
 
 		static byte[] EncodeAddressHeader (ParserOptions options, FormatOptions format, Encoding encoding, string field, string value)
 		{
-			var encoded = new StringBuilder (" ");
-			int lineLength = field.Length + 2;
-
 			if (!InternetAddressList.TryParse (options, value, out var list))
 				return (byte[]) format.NewLineBytes.Clone ();
+
+			var encoded = new StringBuilder (" ");
+			int lineLength = field.Length + 2;
 
 			list.Encode (format, encoded, true, ref lineLength);
 			encoded.Append (format.NewLine);

--- a/MimeKit/MessageIdList.cs
+++ b/MimeKit/MessageIdList.cs
@@ -353,7 +353,7 @@ namespace MimeKit {
 		/// <returns>A string representing the <see cref="MessageIdList"/>.</returns>
 		public override string ToString ()
 		{
-			var builder = new StringBuilder ();
+			var builder = new ValueStringBuilder (128);
 
 			for (int i = 0; i < references.Count; i++) {
 				if (builder.Length > 0)

--- a/MimeKit/MimeIterator.cs
+++ b/MimeKit/MimeIterator.cs
@@ -28,6 +28,7 @@ using System;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace MimeKit {
 	/// <summary>
@@ -205,12 +206,13 @@ namespace MimeKit {
 				if (current == null)
 					throw new InvalidOperationException ();
 
-				var specifier = new StringBuilder ();
+				var specifier = new ValueStringBuilder(128);
 
-				for (int i = 0; i < path.Count; i++)
-					specifier.AppendFormat ("{0}.", path[i] + 1);
-
-				specifier.AppendFormat ("{0}", index + 1);
+				for (int i = 0; i < path.Count; i++) {
+					specifier.Append ((path[i] + 1).ToString (CultureInfo.InvariantCulture));
+					specifier.Append ('.');
+				}
+				specifier.Append ((index + 1).ToString(CultureInfo.InvariantCulture));
 
 				return specifier.ToString ();
 			}

--- a/MimeKit/MimeKit.csproj
+++ b/MimeKit/MimeKit.csproj
@@ -4,6 +4,7 @@
     <Description>An Open Source library for creating and parsing MIME, S/MIME, PGP messages on desktop and mobile platforms.</Description>
     <AssemblyTitle>MimeKit</AssemblyTitle>
     <VersionPrefix>3.1.1</VersionPrefix>
+    <LangVersion>8</LangVersion>
     <Authors>Jeffrey Stedfast</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net452;net46;net47;net48;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -315,6 +316,7 @@
     <Compile Include="RfcComplianceMode.cs" />
     <Compile Include="TextPart.cs" />
     <Compile Include="TextRfc822Headers.cs" />
+    <Compile Include="Utils\ValueStringBuilder.cs" />
     <Compile Include="XMessagePriority.cs" />
   </ItemGroup>
 

--- a/MimeKit/MimeKitLite.csproj
+++ b/MimeKit/MimeKitLite.csproj
@@ -6,6 +6,7 @@
     <VersionPrefix>3.1.1</VersionPrefix>
     <Authors>Jeffrey Stedfast</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net452;net46;net47;net48;net5.0;net6.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AssemblyName>MimeKitLite</AssemblyName>
@@ -214,6 +215,7 @@
     <Compile Include="TextPart.cs" />
     <Compile Include="TextRfc822Headers.cs" />
     <Compile Include="XMessagePriority.cs" />
+    <Compile Include="Utils\ValueStringBuilder.cs" />
   </ItemGroup>
 
 </Project>

--- a/MimeKit/ParameterList.cs
+++ b/MimeKit/ParameterList.cs
@@ -635,7 +635,7 @@ namespace MimeKit {
 		/// <returns>A string representing the <see cref="ParameterList"/>.</returns>
 		public override string ToString ()
 		{
-			var values = new StringBuilder ();
+			var values = new ValueStringBuilder (128);
 
 			foreach (var param in parameters) {
 				values.Append ("; ");

--- a/MimeKit/Utils/MimeUtils.cs
+++ b/MimeKit/Utils/MimeUtils.cs
@@ -423,6 +423,33 @@ namespace MimeKit.Utils {
 		}
 
 		/// <summary>
+		/// Quote the specified text and append it into the value string builder.
+		/// </summary>
+		/// <remarks>
+		/// Quotes the specified text, enclosing it in double-quotes and escaping
+		/// any backslashes and double-quotes within.
+		/// </remarks>
+		/// <returns>The string builder.</returns>
+		/// <param name="builder">The string builder.</param>
+		/// <param name="text">The text to quote.</param>
+		/// <exception cref="System.ArgumentNullException">
+		/// <paramref name="text"/> is <c>null</c>.
+		/// </exception>
+		internal static void AppendQuoted (ref ValueStringBuilder builder, string text)
+		{
+			if (text == null)
+				throw new ArgumentNullException (nameof (text));
+
+			builder.Append ("\"");
+			for (int i = 0; i < text.Length; i++) {
+				if (text[i] == '\\' || text[i] == '"')
+					builder.Append ('\\');
+				builder.Append (text[i]);
+			}
+			builder.Append ("\"");
+		}
+
+		/// <summary>
 		/// Quote the specified text.
 		/// </summary>
 		/// <remarks>

--- a/MimeKit/Utils/MimeUtils.cs
+++ b/MimeKit/Utils/MimeUtils.cs
@@ -82,8 +82,8 @@ namespace MimeKit.Utils {
 			if (domain.Length == 0)
 				throw new ArgumentException ("The domain is invalid.", nameof (domain));
 
-			ulong value = (ulong) DateTime.Now.Ticks;
-			var id = new StringBuilder ();
+			ulong value = (ulong) DateTime.UtcNow.Ticks;
+			var id = new ValueStringBuilder (64);
 			var block = new byte[8];
 
 			GetRandomBytes (block);
@@ -104,7 +104,8 @@ namespace MimeKit.Utils {
 				value /= 36;
 			} while (value != 0);
 
-			id.Append ('@').Append (ParseUtils.IdnEncode (domain));
+			id.Append ('@');
+			id.Append (ParseUtils.IdnEncode (domain));
 
 			return id.ToString ();
 		}
@@ -494,7 +495,7 @@ namespace MimeKit.Utils {
 			if (index == -1)
 				return text;
 
-			var builder = new StringBuilder (text.Length);
+			var builder = new ValueStringBuilder (text.Length);
 			bool escaped = false;
 			bool quoted = false;
 

--- a/MimeKit/Utils/ParseUtils.cs
+++ b/MimeKit/Utils/ParseUtils.cs
@@ -260,7 +260,7 @@ namespace MimeKit.Utils {
 
 		static bool TryParseDotAtom (byte[] text, ref int index, int endIndex, byte[] sentinels, bool throwOnError, string tokenType, out string dotatom)
 		{
-			var token = new StringBuilder ();
+			using var token = new ValueStringBuilder (128);
 			int startIndex = index;
 			int comment;
 
@@ -316,7 +316,8 @@ namespace MimeKit.Utils {
 
 		static bool TryParseDomainLiteral (byte[] text, ref int index, int endIndex, bool throwOnError, out string domain)
 		{
-			var token = new StringBuilder ("[");
+			using var token = new ValueStringBuilder (128);
+			token.Append('[');
 			int startIndex = index++;
 
 			domain = null;
@@ -400,7 +401,7 @@ namespace MimeKit.Utils {
 				return false;
 			}
 
-			var token = new StringBuilder ();
+			using var token = new ValueStringBuilder (128);
 
 			// consume the local-part of the msg-id using a very loose definition of 'local-part'
 			//

--- a/MimeKit/Utils/ValueStringBuilder.cs
+++ b/MimeKit/Utils/ValueStringBuilder.cs
@@ -1,0 +1,296 @@
+﻿#nullable enable
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Text
+{
+	internal ref partial struct ValueStringBuilder
+	{
+		private char[]? _arrayToReturnToPool;
+		private Span<char> _chars;
+		private int _pos;
+
+		public ValueStringBuilder (Span<char> initialBuffer)
+		{
+			_arrayToReturnToPool = null;
+			_chars = initialBuffer;
+			_pos = 0;
+		}
+
+		public ValueStringBuilder (int initialCapacity)
+		{
+			_arrayToReturnToPool = ArrayPool<char>.Shared.Rent (initialCapacity);
+			_chars = _arrayToReturnToPool;
+			_pos = 0;
+		}
+
+		public int Length {
+			get => _pos;
+			set {
+				Debug.Assert (value >= 0);
+				Debug.Assert (value <= _chars.Length);
+				_pos = value;
+			}
+		}
+
+		public int Capacity => _chars.Length;
+
+		public void EnsureCapacity (int capacity)
+		{
+			// This is not expected to be called this with negative capacity
+			Debug.Assert (capacity >= 0);
+
+			// If the caller has a bug and calls this with negative capacity, make sure to call Grow to throw an exception.
+			if ((uint) capacity > (uint) _chars.Length)
+				Grow (capacity - _pos);
+		}
+
+		/// <summary>
+		/// Get a pinnable reference to the builder.
+		/// Does not ensure there is a null char after <see cref="Length"/>
+		/// This overload is pattern matched in the C# 7.3+ compiler so you can omit
+		/// the explicit method call, and write eg "fixed (char* c = builder)"
+		/// </summary>
+		public ref char GetPinnableReference ()
+		{
+			return ref MemoryMarshal.GetReference (_chars);
+		}
+
+		/// <summary>
+		/// Get a pinnable reference to the builder.
+		/// </summary>
+		/// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+		public ref char GetPinnableReference (bool terminate)
+		{
+			if (terminate) {
+				EnsureCapacity (Length + 1);
+				_chars[Length] = '\0';
+			}
+			return ref MemoryMarshal.GetReference (_chars);
+		}
+
+		public ref char this[int index] {
+			get {
+				Debug.Assert (index < _pos);
+				return ref _chars[index];
+			}
+		}
+
+		public override string ToString ()
+		{
+			string s = _chars.Slice (0, _pos).ToString ();
+			Dispose ();
+			return s;
+		}
+
+		/// <summary>Returns the underlying storage of the builder.</summary>
+		public Span<char> RawChars => _chars;
+
+		/// <summary>
+		/// Returns a span around the contents of the builder.
+		/// </summary>
+		/// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+		public ReadOnlySpan<char> AsSpan (bool terminate)
+		{
+			if (terminate) {
+				EnsureCapacity (Length + 1);
+				_chars[Length] = '\0';
+			}
+			return _chars.Slice (0, _pos);
+		}
+
+		public ReadOnlySpan<char> AsSpan () => _chars.Slice (0, _pos);
+		public ReadOnlySpan<char> AsSpan (int start) => _chars.Slice (start, _pos - start);
+		public ReadOnlySpan<char> AsSpan (int start, int length) => _chars.Slice (start, length);
+
+		public bool TryCopyTo (Span<char> destination, out int charsWritten)
+		{
+			if (_chars.Slice (0, _pos).TryCopyTo (destination)) {
+				charsWritten = _pos;
+				Dispose ();
+				return true;
+			} else {
+				charsWritten = 0;
+				Dispose ();
+				return false;
+			}
+		}
+
+		public void Insert (int index, char value, int count)
+		{
+			if (_pos > _chars.Length - count) {
+				Grow (count);
+			}
+
+			int remaining = _pos - index;
+			_chars.Slice (index, remaining).CopyTo (_chars.Slice (index + count));
+			_chars.Slice (index, count).Fill (value);
+			_pos += count;
+		}
+
+		public void Insert (int index, string? s)
+		{
+			if (s == null) {
+				return;
+			}
+
+			int count = s.Length;
+
+			if (_pos > (_chars.Length - count)) {
+				Grow (count);
+			}
+
+			int remaining = _pos - index;
+			_chars.Slice (index, remaining).CopyTo (_chars.Slice (index + count));
+			s
+#if !NET6_0_OR_GREATER
+				.AsSpan ()
+#endif
+				.CopyTo (_chars.Slice (index));
+			_pos += count;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		public void Append (char c)
+		{
+			int pos = _pos;
+			if ((uint) pos < (uint) _chars.Length) {
+				_chars[pos] = c;
+				_pos = pos + 1;
+			} else {
+				GrowAndAppend (c);
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		public void Append (string? s)
+		{
+			if (s == null) {
+				return;
+			}
+
+			int pos = _pos;
+			if (s.Length == 1 && (uint) pos < (uint) _chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+			{
+				_chars[pos] = s[0];
+				_pos = pos + 1;
+			} else {
+				AppendSlow (s);
+			}
+		}
+
+		private void AppendSlow (string s)
+		{
+			int pos = _pos;
+			if (pos > _chars.Length - s.Length) {
+				Grow (s.Length);
+			}
+
+			s
+#if !NET6_0_OR_GREATER
+				.AsSpan ()
+#endif
+				.CopyTo (_chars.Slice (pos));
+			_pos += s.Length;
+		}
+
+		public void Append (char c, int count)
+		{
+			if (_pos > _chars.Length - count) {
+				Grow (count);
+			}
+
+			Span<char> dst = _chars.Slice (_pos, count);
+			for (int i = 0; i < dst.Length; i++) {
+				dst[i] = c;
+			}
+			_pos += count;
+		}
+
+		public unsafe void Append (char* value, int length)
+		{
+			int pos = _pos;
+			if (pos > _chars.Length - length) {
+				Grow (length);
+			}
+
+			Span<char> dst = _chars.Slice (_pos, length);
+			for (int i = 0; i < dst.Length; i++) {
+				dst[i] = *value++;
+			}
+			_pos += length;
+		}
+
+		public void Append (ReadOnlySpan<char> value)
+		{
+			int pos = _pos;
+			if (pos > _chars.Length - value.Length) {
+				Grow (value.Length);
+			}
+
+			value.CopyTo (_chars.Slice (_pos));
+			_pos += value.Length;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		public Span<char> AppendSpan (int length)
+		{
+			int origPos = _pos;
+			if (origPos > _chars.Length - length) {
+				Grow (length);
+			}
+
+			_pos = origPos + length;
+			return _chars.Slice (origPos, length);
+		}
+
+		[MethodImpl (MethodImplOptions.NoInlining)]
+		private void GrowAndAppend (char c)
+		{
+			Grow (1);
+			Append (c);
+		}
+
+		/// <summary>
+		/// Resize the internal buffer either by doubling current buffer size or
+		/// by adding <paramref name="additionalCapacityBeyondPos"/> to
+		/// <see cref="_pos"/> whichever is greater.
+		/// </summary>
+		/// <param name="additionalCapacityBeyondPos">
+		/// Number of chars requested beyond current position.
+		/// </param>
+		[MethodImpl (MethodImplOptions.NoInlining)]
+		private void Grow (int additionalCapacityBeyondPos)
+		{
+			Debug.Assert (additionalCapacityBeyondPos > 0);
+			Debug.Assert (_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+			// Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative
+			char[] poolArray = ArrayPool<char>.Shared.Rent ((int) Math.Max ((uint) (_pos + additionalCapacityBeyondPos), (uint) _chars.Length * 2));
+
+			_chars.Slice (0, _pos).CopyTo (poolArray);
+
+			char[]? toReturn = _arrayToReturnToPool;
+			_chars = _arrayToReturnToPool = poolArray;
+			if (toReturn != null) {
+				ArrayPool<char>.Shared.Return (toReturn);
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		public void Dispose ()
+		{
+			char[]? toReturn = _arrayToReturnToPool;
+			this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+			if (toReturn != null) {
+				ArrayPool<char>.Shared.Return (toReturn);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces and uses a ValueStringBuilder via [dotnet](https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/Common/src/System/Text/ValueStringBuilder.cs).

Under the hood, this uses a dynamically resizing array borrowed from ArrayPool to eliminate allocations. It can also accept stack allocated memory as an initial buffer (expanding to use borrowed heap memory, as needed). 

We must be careful to return the memory after use by calling ToString or Dispose, but otherwise -- this should be a nice net win for throughput.