### PR TITLE
Reduce Allocations (take 2)

### DIFF
--- a/MimeKit/Cryptography/ArcSigner.cs
+++ b/MimeKit/Cryptography/ArcSigner.cs
@@ -233,10 +233,8 @@ namespace MimeKit.Cryptography {
 			return (long) (DateTime.UtcNow - DateUtils.UnixEpoch).TotalSeconds;
 		}
 
-		StringBuilder CreateArcHeaderBuilder (int instance)
+		void WriteArcHeaderBuilder (StringBuilder value, int instance)
 		{
-			var value = new StringBuilder ();
-
 			value.AppendFormat ("i={0}", instance.ToString (CultureInfo.InvariantCulture));
 
 			switch (SignatureAlgorithm) {
@@ -250,13 +248,12 @@ namespace MimeKit.Cryptography {
 				value.Append ("; a=rsa-sha1");
 				break;
 			}
-
-			return value;
 		}
 
 		Header GenerateArcMessageSignature (FormatOptions options, MimeMessage message, int instance, long t, IList<string> headers)
 		{
-			var value = CreateArcHeaderBuilder (instance);
+			var value = new StringBuilder ();
+			WriteArcHeaderBuilder (value, instance);
 			byte[] signature, hash;
 			Header ams;
 
@@ -303,7 +300,8 @@ namespace MimeKit.Cryptography {
 
 		Header GenerateArcSeal (FormatOptions options, int instance, string cv, long t, ArcHeaderSet[] sets, int count, Header aar, Header ams)
 		{
-			var value = CreateArcHeaderBuilder (instance);
+			var value = new StringBuilder ();
+			WriteArcHeaderBuilder (value, instance);
 			byte[] signature;
 			Header seal;
 

--- a/MimeKit/Cryptography/AuthenticationResults.cs
+++ b/MimeKit/Cryptography/AuthenticationResults.cs
@@ -193,7 +193,7 @@ namespace MimeKit.Cryptography {
 
 			if (Instance.HasValue) {
 				builder.Append ("i=");
-				builder.Append(Instance.Value.ToString (CultureInfo.InvariantCulture));
+				builder.AppendInvariant(Instance.Value);
 				builder.Append ("; ");
 			}
 
@@ -202,7 +202,7 @@ namespace MimeKit.Cryptography {
 
 				if (Version.HasValue) {
 					builder.Append (' ');
-					builder.Append (Version.Value.ToString (CultureInfo.InvariantCulture));
+					builder.AppendInvariant (Version.Value);
 				}
 
 				builder.Append ("; ");

--- a/MimeKit/Cryptography/DkimPublicKeyLocatorBase.cs
+++ b/MimeKit/Cryptography/DkimPublicKeyLocatorBase.cs
@@ -89,7 +89,7 @@ namespace MimeKit.Cryptography {
 				if (index == txt.Length)
 					break;
 
-				var key = txt.Substring (startIndex, index - startIndex);
+				ReadOnlySpan<char> key = txt.AsSpan (startIndex, index - startIndex);
 
 				// skip over the '='
 				index++;
@@ -101,16 +101,14 @@ namespace MimeKit.Cryptography {
 
 				var value = txt.Substring (startIndex, index - startIndex);
 
-				switch (key) {
-				case "k":
+				if (key.SequenceEqual ("k".AsSpan ())) {
 					switch (value) {
 					case "rsa": case "ed25519": k = value; break;
 					default: throw new ParseException ($"Unknown public key algorithm: {value}", startIndex, index);
 					}
-					break;
-				case "p":
+				} 
+				else if (key.SequenceEqual ("p".AsSpan ())) {
 					p = value.Replace (" ", "");
-					break;
 				}
 
 				// skip over the ';'

--- a/MimeKit/Cryptography/X509CertificateDatabase.cs
+++ b/MimeKit/Cryptography/X509CertificateDatabase.cs
@@ -40,6 +40,7 @@ using Org.BouncyCastle.Asn1.BC;
 using Org.BouncyCastle.Asn1.Pkcs;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.X509.Store;
+using MimeKit.Utils;
 
 namespace MimeKit.Cryptography {
 	/// <summary>
@@ -282,9 +283,12 @@ namespace MimeKit.Cryptography {
 
 			var algorithms = new List<EncryptionAlgorithm> ();
 			var values = reader.GetString (column);
+			var splitter = new StringSplitter (values.AsSpan (), ',');
 
-			foreach (var token in values.Split (new [] { ',' }, StringSplitOptions.RemoveEmptyEntries)) {
-				if (Enum.TryParse (token.Trim (), true, out EncryptionAlgorithm algorithm))
+			while (splitter.TryReadNext (out var token)) {
+				if (token.IsEmpty) continue;
+
+				if (Enum.TryParse (token.Trim ().ToString(), true, out EncryptionAlgorithm algorithm))
 					algorithms.Add (algorithm);
 			}
 

--- a/MimeKit/MimeIterator.cs
+++ b/MimeKit/MimeIterator.cs
@@ -209,10 +209,11 @@ namespace MimeKit {
 				var specifier = new ValueStringBuilder(128);
 
 				for (int i = 0; i < path.Count; i++) {
-					specifier.Append ((path[i] + 1).ToString (CultureInfo.InvariantCulture));
+					specifier.AppendInvariant (path[i] + 1);
 					specifier.Append ('.');
 				}
-				specifier.Append ((index + 1).ToString(CultureInfo.InvariantCulture));
+
+				specifier.AppendInvariant (index + 1);
 
 				return specifier.ToString ();
 			}

--- a/MimeKit/Multipart.cs
+++ b/MimeKit/Multipart.cs
@@ -341,7 +341,7 @@ namespace MimeKit {
 
 		internal static string FoldPreambleOrEpilogue (FormatOptions options, string text, bool isEpilogue)
 		{
-			var builder = new StringBuilder ();
+			var builder = new ValueStringBuilder (256);
 			int startIndex, wordIndex;
 			int lineLength = 0;
 			int index = 0;
@@ -380,7 +380,7 @@ namespace MimeKit {
 				}
 
 				if (length > 0) {
-					builder.Append (text, startIndex, length);
+					builder.Append (text.AsSpan(startIndex, length));
 					lineLength += length;
 				}
 			}

--- a/MimeKit/Utils/MimeUtils.cs
+++ b/MimeKit/Utils/MimeUtils.cs
@@ -24,8 +24,6 @@
 // THE SOFTWARE.
 //
 
-#nullable enable
-
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -42,7 +40,7 @@ namespace MimeKit.Utils {
 	public static class MimeUtils
 	{
 		const string base36 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-		static string? DefaultHostName = null;
+		static string DefaultHostName = null;
 
 		/// <summary>
 		/// A string comparer that performs a case-insensitive ordinal string comparison.

--- a/MimeKit/Utils/MimeUtils.cs
+++ b/MimeKit/Utils/MimeUtils.cs
@@ -24,6 +24,8 @@
 // THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -40,7 +42,7 @@ namespace MimeKit.Utils {
 	public static class MimeUtils
 	{
 		const string base36 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-		static string DefaultHostName = null;
+		static string? DefaultHostName = null;
 
 		/// <summary>
 		/// A string comparer that performs a case-insensitive ordinal string comparison.
@@ -412,13 +414,13 @@ namespace MimeKit.Utils {
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
 
-			builder.Append ("\"");
+			builder.Append ('"');
 			for (int i = 0; i < text.Length; i++) {
 				if (text[i] == '\\' || text[i] == '"')
 					builder.Append ('\\');
 				builder.Append (text[i]);
 			}
-			builder.Append ("\"");
+			builder.Append ('"');
 
 			return builder;
 		}
@@ -430,24 +432,17 @@ namespace MimeKit.Utils {
 		/// Quotes the specified text, enclosing it in double-quotes and escaping
 		/// any backslashes and double-quotes within.
 		/// </remarks>
-		/// <returns>The string builder.</returns>
-		/// <param name="builder">The string builder.</param>
+		/// <param name="builder">The value string builder.</param>
 		/// <param name="text">The text to quote.</param>
-		/// <exception cref="System.ArgumentNullException">
-		/// <paramref name="text"/> is <c>null</c>.
-		/// </exception>
 		internal static void AppendQuoted (ref ValueStringBuilder builder, string text)
 		{
-			if (text == null)
-				throw new ArgumentNullException (nameof (text));
-
-			builder.Append ("\"");
+			builder.Append ('"');
 			for (int i = 0; i < text.Length; i++) {
 				if (text[i] == '\\' || text[i] == '"')
 					builder.Append ('\\');
 				builder.Append (text[i]);
 			}
-			builder.Append ("\"");
+			builder.Append ('"');
 		}
 
 		/// <summary>
@@ -467,9 +462,9 @@ namespace MimeKit.Utils {
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
 
-			var quoted = new StringBuilder (text.Length + 2, (text.Length * 2) + 2);
+			var quoted = new ValueStringBuilder ((text.Length * 2) + 2);
 
-			AppendQuoted (quoted, text);
+			AppendQuoted (ref quoted, text);
 
 			return quoted.ToString ();
 		}

--- a/MimeKit/Utils/MimeUtils.cs
+++ b/MimeKit/Utils/MimeUtils.cs
@@ -86,10 +86,16 @@ namespace MimeKit.Utils {
 
 			ulong value = (ulong) DateTime.UtcNow.Ticks;
 			var id = new ValueStringBuilder (64);
+
+#if NET6_0_OR_GREATER
+			Span<byte> block = stackalloc byte[8];
+
+			RandomNumberGenerator.Fill (block);
+#else
 			var block = new byte[8];
 
 			GetRandomBytes (block);
-
+#endif
 			do {
 				id.Append (base36[(int) (value % 36)]);
 				value /= 36;

--- a/MimeKit/Utils/MimeUtils.cs
+++ b/MimeKit/Utils/MimeUtils.cs
@@ -54,7 +54,7 @@ namespace MimeKit.Utils {
 
 		internal static void GetRandomBytes (byte[] buffer)
 		{
-#if NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER
 			RandomNumberGenerator.Fill (buffer);
 #else
 			using (var random = RandomNumberGenerator.Create ())

--- a/MimeKit/Utils/Rfc2047.cs
+++ b/MimeKit/Utils/Rfc2047.cs
@@ -177,7 +177,7 @@ namespace MimeKit.Utils {
 			return true;
 		}
 
-		static unsafe IList<Token> TokenizePhrase (ParserOptions options, byte* inbuf, int startIndex, int length)
+		static unsafe List<Token> TokenizePhrase (ParserOptions options, byte* inbuf, int startIndex, int length)
 		{
 			byte* text, word, inptr = inbuf + startIndex;
 			byte* inend = inptr + length;

--- a/MimeKit/Utils/StringBuilderExtensions.cs
+++ b/MimeKit/Utils/StringBuilderExtensions.cs
@@ -139,6 +139,11 @@ namespace MimeKit.Utils {
 				System.Buffers.ArrayPool<char>.Shared.Return (buffer);
 			}
 		}
+
+		public static void Append (this StringBuilder sb, StringBuilder value)
+		{
+			sb.Append (value.ToString ());
+		}
 #endif
 
 #if DEBUG

--- a/MimeKit/Utils/StringSplitter.cs
+++ b/MimeKit/Utils/StringSplitter.cs
@@ -1,0 +1,69 @@
+﻿//
+// StringSplitter.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2022 .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+using System;
+
+namespace MimeKit.Utils
+{
+	internal ref struct StringSplitter
+	{
+		private readonly ReadOnlySpan<char> text;
+		private readonly char seperator;
+		private int position;
+
+		public StringSplitter (ReadOnlySpan<char> text, char seperator)
+		{
+			this.text = text;
+			this.seperator = seperator;
+			this.position = 0;
+		}
+
+		public bool TryReadNext (out ReadOnlySpan<char> item)
+		{
+			if (IsEof) {
+				item = default;
+				return false;
+			}
+
+			int start = position;
+
+			int seperatorIndex = text.Slice (position).IndexOf (seperator);
+
+			if (seperatorIndex > -1) {
+				position += seperatorIndex + 1;
+
+				item = text.Slice (start, seperatorIndex);
+			} else {
+				position = text.Length;
+
+				item = text.Slice (start);
+			}
+
+			return true;
+		}
+
+		public bool IsEof => position == text.Length;
+	}
+}


### PR DESCRIPTION
- Introduces and uses a StringSplitter to avoid array (and array element) allocations
- Use ValueStringBuilder.AppendInvariant(value) to eliminate allocations appending span formattables on NET6+
- Eliminates various byte[] and string allocations