### PR TITLE
Eliminate various string allocations

### DIFF
--- a/MimeKit/ContentDisposition.cs
+++ b/MimeKit/ContentDisposition.cs
@@ -308,7 +308,7 @@ namespace MimeKit {
 			}
 			set {
 				if (value.HasValue)
-					Parameters["size"] = value.Value.ToString ();
+					Parameters["size"] = value.Value.ToString (CultureInfo.InvariantCulture);
 				else
 					Parameters.Remove ("size");
 			}

--- a/MimeKit/Cryptography/AuthenticationResults.cs
+++ b/MimeKit/Cryptography/AuthenticationResults.cs
@@ -191,9 +191,16 @@ namespace MimeKit.Cryptography {
 		{
 			var builder = new ValueStringBuilder (256);
 
+			WriteTo (ref builder);
+
+			return builder.ToString ();
+		}
+
+		internal void WriteTo (ref ValueStringBuilder builder)
+		{
 			if (Instance.HasValue) {
 				builder.Append ("i=");
-				builder.AppendInvariant(Instance.Value);
+				builder.AppendInvariant (Instance.Value);
 				builder.Append ("; ");
 			}
 
@@ -212,13 +219,12 @@ namespace MimeKit.Cryptography {
 				for (int i = 0; i < Results.Count; i++) {
 					if (i > 0)
 						builder.Append ("; ");
-					builder.Append (Results[i].ToString());
+
+					Results[i].WriteTo (ref builder);
 				}
 			} else {
 				builder.Append ("none");
 			}
-
-			return builder.ToString ();
 		}
 
 		static bool IsKeyword (byte c)
@@ -1160,6 +1166,13 @@ namespace MimeKit.Cryptography {
 		{
 			var builder = new ValueStringBuilder (128);
 
+			WriteTo (ref builder);
+
+			return builder.ToString ();
+		}
+
+		internal void WriteTo (ref ValueStringBuilder builder)
+		{
 			if (Office365AuthenticationServiceIdentifier != null) {
 				builder.Append (Office365AuthenticationServiceIdentifier);
 				builder.Append ("; ");
@@ -1169,7 +1182,7 @@ namespace MimeKit.Cryptography {
 
 			if (Version.HasValue) {
 				builder.Append ('/');
-				builder.Append (Version.Value.ToString (CultureInfo.InvariantCulture));
+				builder.AppendInvariant (Version.Value);
 			}
 
 			builder.Append ('=');
@@ -1183,18 +1196,16 @@ namespace MimeKit.Cryptography {
 
 			if (!string.IsNullOrEmpty (Reason)) {
 				builder.Append (" reason=");
-				MimeUtils.AppendQuoted (ref builder, Reason);
+				builder.AppendQuoted (Reason);
 			} else if (!string.IsNullOrEmpty (Action)) {
 				builder.Append (" action=");
-				MimeUtils.AppendQuoted (ref builder, Action);
+				builder.AppendQuoted (Action);
 			}
 
 			for (int i = 0; i < Properties.Count; i++) {
 				builder.Append (' ');
-				builder.Append (Properties[i].ToString());
+				Properties[i].WriteTo (ref builder);
 			}
-
-			return builder.ToString ();
 		}
 	}
 
@@ -1326,10 +1337,27 @@ namespace MimeKit.Cryptography {
 		/// <returns>The serialized string.</returns>
 		public override string ToString ()
 		{
-			var quote = quoted.HasValue ? quoted.Value : Value.IndexOfAny (TokenSpecials) != -1;
-			var value = quote ? MimeUtils.Quote (Value) : Value;
+			var builder = new ValueStringBuilder (128);
 
-			return $"{PropertyType}.{Property}={value}";
+			WriteTo (ref builder);
+
+			return builder.ToString ();
+		}
+
+		internal void WriteTo (ref ValueStringBuilder builder)
+		{
+			bool quote = quoted.HasValue ? quoted.Value : Value.IndexOfAny (TokenSpecials) != -1;
+
+			builder.Append (PropertyType);
+			builder.Append ('.');
+			builder.Append (Property);
+			builder.Append ('=');
+
+			if (quote) {
+				builder.AppendQuoted(Value);
+			} else {
+				builder.Append (Value);
+			}
 		}
 	}
 }

--- a/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
+++ b/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
@@ -195,7 +195,7 @@ namespace MimeKit.Cryptography {
 			var hex = new ValueStringBuilder (blob.Length * 2);
 
 			for (int i = 0; i < blob.Length; i++)
-				hex.Append (blob[i].ToString ("x2"));
+				hex.AppendInvariant (blob[i], "x2");
 
 			return hex.ToString ();
 		}

--- a/MimeKit/DomainList.cs
+++ b/MimeKit/DomainList.cs
@@ -351,7 +351,7 @@ namespace MimeKit {
 		/// <returns>A string representing the <see cref="DomainList"/>.</returns>
 		public override string ToString ()
 		{
-			var builder = new ValueStringBuilder ();
+			var builder = new ValueStringBuilder (128);
 
 			for (int i = 0; i < domains.Count; i++) {
 				if (string.IsNullOrWhiteSpace (domains[i]))

--- a/MimeKit/MimePart.cs
+++ b/MimeKit/MimePart.cs
@@ -287,7 +287,7 @@ namespace MimeKit {
 				duration = value;
 
 				if (value.HasValue) {
-					SetHeader ("Content-Duration", value.Value.ToString ());
+					SetHeader ("Content-Duration", value.Value.ToString (CultureInfo.InvariantCulture));
 				} else {
 					RemoveHeader ("Content-Duration");
 				}

--- a/MimeKit/Utils/MimeUtils.cs
+++ b/MimeKit/Utils/MimeUtils.cs
@@ -469,7 +469,7 @@ namespace MimeKit.Utils {
 		/// </remarks>
 		/// <param name="builder">The value string builder.</param>
 		/// <param name="text">The text to quote.</param>
-		internal static void AppendQuoted (ref ValueStringBuilder builder, string text)
+		internal static void AppendQuoted (this ref ValueStringBuilder builder, string text)
 		{
 			AppendQuoted (ref builder, text.AsSpan ());
 		}

--- a/MimeKit/Utils/ValueStringBuilder.cs
+++ b/MimeKit/Utils/ValueStringBuilder.cs
@@ -286,12 +286,12 @@ namespace System.Text {
 #endif
 
 #if NET6_0_OR_GREATER
-		internal void AppendInvariant<T> (T value) where T : ISpanFormattable
+		internal void AppendInvariant<T> (T value, string? format = null) where T : ISpanFormattable
 		{
-			if (value.TryFormat (_chars.Slice (_pos), out int charsWritten, null, CultureInfo.InvariantCulture)) {
+			if (value.TryFormat (_chars.Slice (_pos), out int charsWritten, format, CultureInfo.InvariantCulture)) {
 				_pos += charsWritten;
 			} else {
-				Append (value.ToString (null, CultureInfo.InvariantCulture));
+				Append (value.ToString (format, CultureInfo.InvariantCulture));
 			}
 		}
 
@@ -306,9 +306,9 @@ namespace System.Text {
 		}
 #endif
 #else
-		internal void AppendInvariant<T> (T value, string? format = null, IFormatProvider? provider = null) where T: IFormattable
+		internal void AppendInvariant<T> (T value, string? format = null) where T: IFormattable
 		{
-			Append (value.ToString (null, CultureInfo.InvariantCulture));	
+			Append (value.ToString (format, CultureInfo.InvariantCulture));	
 		}
 
 #if UNUSED_VALUESTRINGBUILDER_API


### PR DESCRIPTION
- Use CultureInfo.InvariantCulture when formatting integers
- Eliminates various string allocations