### PR TITLE
Fix `MemoryBlockStream.Read` method.

### DIFF
--- a/MimeKit/IO/MemoryBlockStream.cs
+++ b/MimeKit/IO/MemoryBlockStream.cs
@@ -239,7 +239,8 @@ namespace MimeKit.IO {
 			if (position == MaxCapacity)
 				return 0;
 
-			int max = Math.Min ((int) (length - position), count);
+			long nrest = length - position;
+			int max =  nrest < int.MaxValue ? Math.Min ((int)nrest, count) : count;
 			int startIndex = (int) (position % BlockSize);
 			int block = (int) (position / BlockSize);
 			int nread = 0;


### PR DESCRIPTION
`Math.Min` may return a negative value when the difference between
`length` and `position` is not in the range of `int`. It happens because
of the numeric conversion from `long` to `int`.

As a result, the `Read` method does not read a single byte.

This situation is possible when the length of the stream is greater than
`int.Max`.