### PR TITLE
Remove unused pragmas

### DIFF
--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -1439,11 +1439,7 @@ namespace MimeKit {
 				}
 			} else {
 				// Note: The only way to get here is if we have an invalid header, in which case the entire 'header' is stored as the 'field'.
-#if NET46_OR_GREATER || NET5_0_OR_GREATER || NETSTANDARD
 				value = Array.Empty<byte> ();
-#else
-				value = new byte[0];
-#endif
 			}
 
 			header = new Header (options, field, value, invalid);

--- a/MimeKit/IO/FilteredStream.cs
+++ b/MimeKit/IO/FilteredStream.cs
@@ -666,11 +666,7 @@ namespace MimeKit.IO {
 				return;
 
 			if (!flushed) {
-#if NET46_OR_GREATER || NET5_0_OR_GREATER || NETSTANDARD
 				filtered = Array.Empty<byte> ();
-#else
-				filtered = new byte[0];
-#endif
 				filteredIndex = 0;
 				filteredLength = 0;
 
@@ -746,11 +742,7 @@ namespace MimeKit.IO {
 				return;
 
 			if (!flushed) {
-#if NET46_OR_GREATER || NET5_0_OR_GREATER || NETSTANDARD
 				filtered = Array.Empty<byte> ();
-#else
-				filtered = new byte[0];
-#endif
 				filteredIndex = 0;
 				filteredLength = 0;
 

--- a/MimeKit/IO/MeasuringStream.cs
+++ b/MimeKit/IO/MeasuringStream.cs
@@ -291,11 +291,7 @@ namespace MimeKit.IO {
 		{
 			Write (buffer, offset, count);
 
-#if NET46_OR_GREATER || NETSTANDARD || NET5_0_OR_GREATER
 			return Task.CompletedTask;
-#else
-			return Task.FromResult (0);
-#endif
 		}
 
 		/// <summary>
@@ -381,11 +377,7 @@ namespace MimeKit.IO {
 			CheckDisposed ();
 
 			// nothing to do...
-#if NET46_OR_GREATER || NETSTANDARD || NET5_0_OR_GREATER
 			return Task.CompletedTask;
-#else
-			return Task.FromResult (0);
-#endif
 		}
 
 		/// <summary>

--- a/MimeKit/IO/MemoryBlockStream.cs
+++ b/MimeKit/IO/MemoryBlockStream.cs
@@ -296,11 +296,7 @@ namespace MimeKit.IO {
 
 				return lastReadTask;
 			} catch (Exception ex) {
-#if NET46_OR_GREATER || NETSTANDARD || NET5_0_OR_GREATER
 				return Task.FromException<int> (ex);
-#else
-				throw;
-#endif
 			}
 		}
 
@@ -402,11 +398,7 @@ namespace MimeKit.IO {
 		{
 			Write (buffer, offset, count);
 
-#if NET46_OR_GREATER || NETSTANDARD || NET5_0_OR_GREATER
 			return Task.CompletedTask;
-#else
-			return Task.FromResult (0);
-#endif
 		}
 
 		/// <summary>
@@ -500,11 +492,7 @@ namespace MimeKit.IO {
 		{
 			CheckDisposed ();
 
-#if NET46_OR_GREATER || NETSTANDARD || NET5_0_OR_GREATER
 			return Task.CompletedTask;
-#else
-			return Task.FromResult (0);
-#endif
 		}
 
 		/// <summary>

--- a/MimeKit/MailboxAddress.cs
+++ b/MimeKit/MailboxAddress.cs
@@ -46,11 +46,7 @@ namespace MimeKit {
 	/// </remarks>
 	public class MailboxAddress : InternetAddress
 	{
-#if NET46_OR_GREATER || NET5_0_OR_GREATER || NETSTANDARD
 		static readonly byte[] EmptySentinels = Array.Empty<byte> ();
-#else
-		static readonly byte[] EmptySentinels = new byte[0];
-#endif
 
 		/// <summary>
 		/// Get or set the punycode implementation that should be used for encoding and decoding mailbox addresses.

--- a/MimeKit/MimeEntity.cs
+++ b/MimeKit/MimeEntity.cs
@@ -618,11 +618,7 @@ namespace MimeKit {
 			if (!contentOnly)
 				return Headers.WriteToAsync (options, stream, cancellationToken);
 
-#if NET46_OR_GREATER || NETSTANDARD || NET5_0_OR_GREATER
 			return Task.CompletedTask;
-#else
-			return Task.FromResult (0);
-#endif
 		}
 
 		/// <summary>

--- a/MimeKit/MimeReader.cs
+++ b/MimeKit/MimeReader.cs
@@ -96,11 +96,7 @@ namespace MimeKit {
 
 		static MimeReader ()
 		{
-#if NET46_OR_GREATER || NET5_0_OR_GREATER || NETSTANDARD
 			CompletedTask = Task.CompletedTask;
-#else
-			CompletedTask = Task.FromResult (true);
-#endif
 		}
 
 		/// <summary>
@@ -1573,11 +1569,7 @@ namespace MimeKit {
 				field = new byte[headerIndex];
 				Buffer.BlockCopy (headerBuffer, 0, field, 0, headerIndex);
 				fieldNameLength = headerIndex;
-#if NET46_OR_GREATER || NET5_0_OR_GREATER || NETSTANDARD
 				value = Array.Empty<byte> ();
-#else
-				value = new byte[0];
-#endif
 			} else {
 				field = new byte[headerFieldLength];
 				Buffer.BlockCopy (headerBuffer, 0, field, 0, headerFieldLength);


### PR DESCRIPTION
Now that we've dropped net451, we can also remove some legacy logic.