### PR TITLE
Added two overloads that don't require a name

### DIFF
--- a/MimeKit/MailboxAddress.cs
+++ b/MimeKit/MailboxAddress.cs
@@ -215,7 +215,7 @@ namespace MimeKit {
 		/// <exception cref="ParseException">
 		/// <paramref name="address"/> is malformed.
 		/// </exception>
-		public MailboxAddress (string address) : this (Encoding.UTF8, address, address)
+		public MailboxAddress (string address) : this (address, address)
 		{
 		}
 

--- a/MimeKit/MailboxAddress.cs
+++ b/MimeKit/MailboxAddress.cs
@@ -167,6 +167,27 @@ namespace MimeKit {
 		/// Initialize a new instance of the <see cref="MailboxAddress"/> class.
 		/// </summary>
 		/// <remarks>
+		/// Creates a new <see cref="MailboxAddress"/> with the specified name (as address) and address. The
+		/// specified text encoding is used when encoding the name according to the rules of rfc2047.
+		/// </remarks>
+		/// <param name="encoding">The character encoding to be used for encoding the name.</param>
+		/// <param name="address">The address of the mailbox.</param>
+		/// <exception cref="System.ArgumentNullException">
+		/// <para><paramref name="encoding"/> is <c>null</c>.</para>
+		/// <para>-or-</para>
+		/// <para><paramref name="address"/> is <c>null</c>.</para>
+		/// </exception>
+		/// <exception cref="ParseException">
+		/// <paramref name="address"/> is malformed.
+		/// </exception>
+		public MailboxAddress (Encoding encoding, string address) : this (encoding, address, address)
+		{
+		}
+
+		/// <summary>
+		/// Initialize a new instance of the <see cref="MailboxAddress"/> class.
+		/// </summary>
+		/// <remarks>
 		/// Creates a new <see cref="MailboxAddress"/> with the specified name and address.
 		/// </remarks>
 		/// <param name="name">The name of the mailbox.</param>
@@ -178,6 +199,23 @@ namespace MimeKit {
 		/// <paramref name="address"/> is malformed.
 		/// </exception>
 		public MailboxAddress (string name, string address) : this (Encoding.UTF8, name, address)
+		{
+		}
+
+		/// <summary>
+		/// Initialize a new instance of the <see cref="MailboxAddress"/> class.
+		/// </summary>
+		/// <remarks>
+		/// Creates a new <see cref="MailboxAddress"/> with the specified name (as address) and address.
+		/// </remarks>
+		/// <param name="address">The address of the mailbox.</param>
+		/// <exception cref="System.ArgumentNullException">
+		/// <paramref name="address"/> is <c>null</c>.
+		/// </exception>
+		/// <exception cref="ParseException">
+		/// <paramref name="address"/> is malformed.
+		/// </exception>
+		public MailboxAddress (string address) : this (Encoding.UTF8, address, address)
 		{
 		}
 


### PR DESCRIPTION
In many cases I don't care about an actual name; when some monitoring or logging system or a 'bot' is sending email there is no 'real name' anyway - setting the name equal to the address is fine (for me) in that situation. This commit adds two 'convenience constructors' which do away with the name argument and set the name to the given address by calling the overloaded constructors with the address value for the name argument.