### PR TITLE
[Tests] Enable ImplictUsings

### DIFF
--- a/UnitTests/ArgumentExceptionTests.cs
+++ b/UnitTests/ArgumentExceptionTests.cs
@@ -24,19 +24,16 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Reflection;
 
-using NUnit.Framework;
-
 using MimeKit;
-using MimeKit.IO;
-using MimeKit.Utils;
-using MimeKit.IO.Filters;
 using MimeKit.Cryptography;
+using MimeKit.IO;
+using MimeKit.IO.Filters;
+using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class ArgumentExceptionTests
 	{

--- a/UnitTests/AssortedTests.cs
+++ b/UnitTests/AssortedTests.cs
@@ -24,18 +24,14 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Globalization;
-
-using NUnit.Framework;
+using System.Text;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class AssortedTests
 	{

--- a/UnitTests/AttachmentCollectionTests.cs
+++ b/UnitTests/AttachmentCollectionTests.cs
@@ -24,12 +24,6 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
-
 using MimeKit;
 
 namespace UnitTests

--- a/UnitTests/ConstructorTests.cs
+++ b/UnitTests/ConstructorTests.cs
@@ -24,19 +24,14 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Collections.Generic;
 using System.Security.Cryptography;
-
-using NUnit.Framework;
+using System.Text;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class ConstructorTests
 	{

--- a/UnitTests/ContentDispositionTests.cs
+++ b/UnitTests/ContentDispositionTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class ContentDispositionTests
 	{

--- a/UnitTests/ContentTypeTests.cs
+++ b/UnitTests/ContentTypeTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class ContentTypeTests
 	{

--- a/UnitTests/Cryptography/ApplicationPkcs7MimeTests.cs
+++ b/UnitTests/Cryptography/ApplicationPkcs7MimeTests.cs
@@ -24,24 +24,19 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
-
-using NUnit.Framework;
-
-using Org.BouncyCastle.X509;
-using Org.BouncyCastle.Security;
-using Org.BouncyCastle.Crypto.Prng;
 
 using MimeKit;
 using MimeKit.Cryptography;
 
+using Org.BouncyCastle.Crypto.Prng;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+
 using BCX509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public abstract class ApplicationPkcs7MimeTestsBase
 	{

--- a/UnitTests/Cryptography/ArcSignerTests.cs
+++ b/UnitTests/Cryptography/ArcSignerTests.cs
@@ -24,21 +24,17 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-using System.Collections.Generic;
-
-using NUnit.Framework;
-
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.OpenSsl;
-using Org.BouncyCastle.Crypto.Parameters;
 
 using MimeKit;
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.OpenSsl;
+
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class ArcSignerTests
 	{

--- a/UnitTests/Cryptography/ArcVerifierTests.cs
+++ b/UnitTests/Cryptography/ArcVerifierTests.cs
@@ -24,11 +24,7 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Cryptography;

--- a/UnitTests/Cryptography/AsymmetricAlgorithmExtensionTests.cs
+++ b/UnitTests/Cryptography/AsymmetricAlgorithmExtensionTests.cs
@@ -24,16 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Security.Cryptography;
 
-using NUnit.Framework;
+using MimeKit.Cryptography;
 
-using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Parameters;
-
-using MimeKit.Cryptography;
+using Org.BouncyCastle.Math;
 
 namespace UnitTests.Cryptography
 {

--- a/UnitTests/Cryptography/AuthenticationResultsTests.cs
+++ b/UnitTests/Cryptography/AuthenticationResultsTests.cs
@@ -24,15 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class AuthenticationResultsTests
 	{

--- a/UnitTests/Cryptography/BouncyCastleSecureMimeContextTests.cs
+++ b/UnitTests/Cryptography/BouncyCastleSecureMimeContextTests.cs
@@ -24,15 +24,11 @@
 // THE SOFTWARE.
 //
 
-using System;
+using MimeKit.Cryptography;
 
 using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Asn1.Smime;
-
-using NUnit.Framework;
-
-using MimeKit.Cryptography;
+using Org.BouncyCastle.Asn1.X509;
 
 namespace UnitTests.Cryptography
 {

--- a/UnitTests/Cryptography/CertificateExtensionTests.cs
+++ b/UnitTests/Cryptography/CertificateExtensionTests.cs
@@ -24,22 +24,18 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Security.Cryptography.X509Certificates;
 
-using MimeKit;
 using MimeKit.Cryptography;
 
-using Org.BouncyCastle.X509;
 using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.X509;
 
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 using X509KeyUsageFlags = MimeKit.Cryptography.X509KeyUsageFlags;
 
-using NUnit.Framework;
-
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class CertificateExtensionTests
 	{

--- a/UnitTests/Cryptography/CmsRecipientTests.cs
+++ b/UnitTests/Cryptography/CmsRecipientTests.cs
@@ -24,19 +24,14 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Security.Cryptography.X509Certificates;
-
-using NUnit.Framework;
-
-using Org.BouncyCastle.X509;
-
-using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
+
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class CmsRecipientTests
 	{

--- a/UnitTests/Cryptography/CmsSignerTests.cs
+++ b/UnitTests/Cryptography/CmsSignerTests.cs
@@ -24,24 +24,20 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 
-using NUnit.Framework;
+using MimeKit.Cryptography;
 
-using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
-
-using MimeKit.Cryptography;
 
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 using X509KeyUsageFlags = MimeKit.Cryptography.X509KeyUsageFlags;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class CmsSignerTests
 	{

--- a/UnitTests/Cryptography/DefaultSecureMimeContextTests.cs
+++ b/UnitTests/Cryptography/DefaultSecureMimeContextTests.cs
@@ -24,26 +24,20 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
 using System.Data.Common;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
-
-using Org.BouncyCastle.X509;
-using Org.BouncyCastle.Asn1.X509;
-using Org.BouncyCastle.Security;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Cryptography;
 
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class DefaultSecureMimeContextTests
 	{

--- a/UnitTests/Cryptography/DkimPublicKeyLocator.cs
+++ b/UnitTests/Cryptography/DkimPublicKeyLocator.cs
@@ -24,14 +24,9 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
+using MimeKit.Cryptography;
 
 using Org.BouncyCastle.Crypto;
-
-using MimeKit.Cryptography;
 
 namespace UnitTests.Cryptography
 {

--- a/UnitTests/Cryptography/DkimPublicKeyLocatorBaseTests.cs
+++ b/UnitTests/Cryptography/DkimPublicKeyLocatorBaseTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-
-using NUnit.Framework;
-
 using MimeKit;
+
 using Org.BouncyCastle.Crypto.Parameters;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class DkimPublicKeyLocatorBaseTests
 	{

--- a/UnitTests/Cryptography/DkimRelaxedBodyFilterTests.cs
+++ b/UnitTests/Cryptography/DkimRelaxedBodyFilterTests.cs
@@ -24,20 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-using System.Threading;
 
-using NUnit.Framework;
-
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.OpenSsl;
-
-using MimeKit;
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class DkimRelaxedBodyFilterTests
 	{

--- a/UnitTests/Cryptography/DkimTests.cs
+++ b/UnitTests/Cryptography/DkimTests.cs
@@ -24,22 +24,15 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-
-using NUnit.Framework;
-
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.OpenSsl;
-using Org.BouncyCastle.Crypto.Parameters;
-
 using MimeKit;
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.OpenSsl;
+
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class DkimTests
 	{

--- a/UnitTests/Cryptography/DummyArcSigner.cs
+++ b/UnitTests/Cryptography/DummyArcSigner.cs
@@ -24,18 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
-using Org.BouncyCastle.Crypto;
-
 using MimeKit;
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+using Org.BouncyCastle.Crypto;
+
+namespace UnitTests.Cryptography
+{
 	public class DummyArcSigner : ArcSigner
 	{
 		public DummyArcSigner (Stream stream, string domain, string selector, DkimSignatureAlgorithm algorithm = DkimSignatureAlgorithm.RsaSha256) : base (stream, domain, selector, algorithm)

--- a/UnitTests/Cryptography/DummyOpenPgpContext.cs
+++ b/UnitTests/Cryptography/DummyOpenPgpContext.cs
@@ -24,11 +24,12 @@
 // THE SOFTWARE.
 //
 
-using Org.BouncyCastle.Bcpg.OpenPgp;
-
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+using Org.BouncyCastle.Bcpg.OpenPgp;
+
+namespace UnitTests.Cryptography
+{
 	public class DummyOpenPgpContext : GnuPGContext
 	{
 		public DummyOpenPgpContext ()

--- a/UnitTests/Cryptography/LdapUriTests.cs
+++ b/UnitTests/Cryptography/LdapUriTests.cs
@@ -27,8 +27,6 @@
 #if ENABLE_LDAP
 using System.DirectoryServices.Protocols;
 
-using NUnit.Framework;
-
 using MimeKit.Cryptography;
 
 namespace UnitTests.Cryptography

--- a/UnitTests/Cryptography/PgpMimeTests.cs
+++ b/UnitTests/Cryptography/PgpMimeTests.cs
@@ -24,24 +24,16 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-
-using NUnit.Framework;
+using MimeKit;
+using MimeKit.Cryptography;
+using MimeKit.IO;
+using MimeKit.IO.Filters;
 
 using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Bcpg.OpenPgp;
 
-using MimeKit;
-using MimeKit.IO;
-using MimeKit.IO.Filters;
-using MimeKit.Cryptography;
-
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class PgpMimeTests
 	{

--- a/UnitTests/Cryptography/RsaEncryptionPaddingTests.cs
+++ b/UnitTests/Cryptography/RsaEncryptionPaddingTests.cs
@@ -24,21 +24,18 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Reflection;
-using System.Collections.Generic;
-
-using NUnit.Framework;
-
-using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Asn1.Oiw;
-using Org.BouncyCastle.Asn1.Nist;
-using Org.BouncyCastle.Asn1.Pkcs;
-using Org.BouncyCastle.Asn1.X509;
 
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.Nist;
+using Org.BouncyCastle.Asn1.Oiw;
+using Org.BouncyCastle.Asn1.Pkcs;
+using Org.BouncyCastle.Asn1.X509;
+
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class RsaEncryptionPaddingTests
 	{

--- a/UnitTests/Cryptography/RsaSignaturePaddingTests.cs
+++ b/UnitTests/Cryptography/RsaSignaturePaddingTests.cs
@@ -24,22 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Reflection;
-using System.Collections.Generic;
-
-using NUnit.Framework;
-
-using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Asn1.Cms;
-using Org.BouncyCastle.Asn1.Oiw;
-using Org.BouncyCastle.Asn1.Nist;
-using Org.BouncyCastle.Asn1.Pkcs;
-using Org.BouncyCastle.Asn1.X509;
 
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class RsaSignaturePaddingTests
 	{

--- a/UnitTests/Cryptography/SecureMimeDigitalCertificateTests.cs
+++ b/UnitTests/Cryptography/SecureMimeDigitalCertificateTests.cs
@@ -24,19 +24,16 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Security.Cryptography.X509Certificates;
-
-using Org.BouncyCastle.OpenSsl;
-
-using NUnit.Framework;
 
 using MimeKit.Cryptography;
 
+using Org.BouncyCastle.OpenSsl;
+
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class SecureMimeDigitalCertificateTests
 	{

--- a/UnitTests/Cryptography/SecureMimeTests.cs
+++ b/UnitTests/Cryptography/SecureMimeTests.cs
@@ -24,28 +24,20 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
-
-using NUnit.Framework;
-
-using Org.BouncyCastle.Cms;
-using Org.BouncyCastle.X509;
-using Org.BouncyCastle.Pkcs;
-using Org.BouncyCastle.Security;
-using Org.BouncyCastle.Crypto.Prng;
 
 using MimeKit;
 using MimeKit.Cryptography;
 
+using Org.BouncyCastle.Crypto.Prng;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	public abstract class SecureMimeTestsBase
 	{
 		//const string ExpiredCertificateMessage = "A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file.\r\n";

--- a/UnitTests/Cryptography/SqliteCertificateDatabaseTests.cs
+++ b/UnitTests/Cryptography/SqliteCertificateDatabaseTests.cs
@@ -24,18 +24,14 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-
-using NUnit.Framework;
-
-using Org.BouncyCastle.X509;
-using Org.BouncyCastle.Asn1.X509;
-using Org.BouncyCastle.X509.Store;
-
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Store;
+
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class SqliteCertificateDatabaseTests : IDisposable
 	{

--- a/UnitTests/Cryptography/TemporarySecureMimeContextTests.cs
+++ b/UnitTests/Cryptography/TemporarySecureMimeContextTests.cs
@@ -24,16 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System.IO;
-using System.Threading.Tasks;
 using System.Security.Cryptography.X509Certificates;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class TemporarySecureMimeContextTests
 	{

--- a/UnitTests/Cryptography/UnknownCryptographyContext.cs
+++ b/UnitTests/Cryptography/UnknownCryptographyContext.cs
@@ -24,11 +24,6 @@
 // THE SOFTWARE.
 //
 
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-
 using MimeKit;
 using MimeKit.Cryptography;
 

--- a/UnitTests/Cryptography/X509CertificateChainTests.cs
+++ b/UnitTests/Cryptography/X509CertificateChainTests.cs
@@ -24,19 +24,14 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
 using System.Collections;
-using System.Collections.Generic;
-
-using Org.BouncyCastle.X509;
-
-using NUnit.Framework;
 
 using MimeKit.Cryptography;
 
-namespace UnitTests.Cryptography {
+using Org.BouncyCastle.X509;
+
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class X509CertificateChainTests
 	{

--- a/UnitTests/Cryptography/X509CertificateRecordTests.cs
+++ b/UnitTests/Cryptography/X509CertificateRecordTests.cs
@@ -24,18 +24,14 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
+using MimeKit.Cryptography;
 
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.OpenSsl;
 using Org.BouncyCastle.X509;
 
-using NUnit.Framework;
-
-using MimeKit.Cryptography;
-
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class X509CertificateRecordTests
 	{

--- a/UnitTests/Cryptography/X509CertificateStoreTests.cs
+++ b/UnitTests/Cryptography/X509CertificateStoreTests.cs
@@ -24,18 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Collections.Generic;
+using MimeKit.Cryptography;
 
 using Org.BouncyCastle.X509;
 
-using NUnit.Framework;
-
-using MimeKit.Cryptography;
-
-namespace UnitTests.Cryptography {
+namespace UnitTests.Cryptography
+{
 	[TestFixture]
 	public class X509CertificateStoreTests
 	{

--- a/UnitTests/DomainListTests.cs
+++ b/UnitTests/DomainListTests.cs
@@ -24,13 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-
-using NUnit.Framework;
-
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class DomainListTests
 	{

--- a/UnitTests/Encodings/EncoderTests.cs
+++ b/UnitTests/Encodings/EncoderTests.cs
@@ -24,21 +24,18 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Text;
 using System.Reflection;
 using System.Security.Cryptography;
-
-using NUnit.Framework;
+using System.Text;
 
 using MimeKit;
-using MimeKit.IO;
-using MimeKit.Utils;
-using MimeKit.IO.Filters;
 using MimeKit.Encodings;
+using MimeKit.IO;
+using MimeKit.IO.Filters;
+using MimeKit.Utils;
 
-namespace UnitTests.Encodings {
+namespace UnitTests.Encodings
+{
 	[TestFixture]
 	public class EncoderTests
 	{

--- a/UnitTests/Encodings/PunycodeTests.cs
+++ b/UnitTests/Encodings/PunycodeTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Globalization;
-
-using NUnit.Framework;
 
 using MimeKit.Encodings;
 
-namespace UnitTests.Encodings {
+namespace UnitTests.Encodings
+{
 	[TestFixture]
 	public class PunycodeTests
 	{

--- a/UnitTests/Encodings/YEncodingTests.cs
+++ b/UnitTests/Encodings/YEncodingTests.cs
@@ -24,18 +24,15 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
-using NUnit.Framework;
-
 using MimeKit;
+using MimeKit.Encodings;
 using MimeKit.IO;
 using MimeKit.IO.Filters;
-using MimeKit.Encodings;
 
-namespace UnitTests.Encodings {
+namespace UnitTests.Encodings
+{
 	[TestFixture]
 	public class YEncodingTests
 	{

--- a/UnitTests/ExceptionTests.cs
+++ b/UnitTests/ExceptionTests.cs
@@ -24,15 +24,11 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
-using NUnit.Framework;
-
 using MimeKit;
-using MimeKit.Tnef;
 using MimeKit.Cryptography;
+using MimeKit.Tnef;
 
 namespace UnitTests
 {

--- a/UnitTests/ExperimentalMimeParserTests.cs
+++ b/UnitTests/ExperimentalMimeParserTests.cs
@@ -24,21 +24,14 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-
-using NUnit.Framework;
-
-using Newtonsoft.Json;
 
 using MimeKit;
 using MimeKit.IO;
-using MimeKit.Utils;
 using MimeKit.IO.Filters;
+using MimeKit.Utils;
+
+using Newtonsoft.Json;
 
 namespace UnitTests
 {

--- a/UnitTests/FormatOptionsTests.cs
+++ b/UnitTests/FormatOptionsTests.cs
@@ -24,13 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-
-using NUnit.Framework;
-
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class FormatOptionsTests
 	{

--- a/UnitTests/GroupAddressTests.cs
+++ b/UnitTests/GroupAddressTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class GroupAddressTests
 	{

--- a/UnitTests/HeaderListCollectionTests.cs
+++ b/UnitTests/HeaderListCollectionTests.cs
@@ -24,16 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Text;
-
-using NUnit.Framework;
-
-using MimeKit;
 using System.Collections;
 
-namespace UnitTests {
+using MimeKit;
+
+namespace UnitTests
+{
 	[TestFixture]
 	public class HeaderListCollectionTests
 	{

--- a/UnitTests/HeaderListTests.cs
+++ b/UnitTests/HeaderListTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class HeaderListTests
 	{

--- a/UnitTests/HeaderTests.cs
+++ b/UnitTests/HeaderTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-using NUnit.Framework;
 
 using MimeKit;
-using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class HeaderTests
 	{

--- a/UnitTests/HtmlPreviewVisitor.cs
+++ b/UnitTests/HtmlPreviewVisitor.cs
@@ -24,9 +24,6 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.Collections.Generic;
-
 using MimeKit;
 using MimeKit.Text;
 

--- a/UnitTests/IO/BoundStreamTests.cs
+++ b/UnitTests/IO/BoundStreamTests.cs
@@ -24,16 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
 
 using MimeKit.IO;
 
-namespace UnitTests.IO {
+namespace UnitTests.IO
+{
 	[TestFixture]
 	public class BoundStreamTests
 	{

--- a/UnitTests/IO/CanReadWriteSeekStream.cs
+++ b/UnitTests/IO/CanReadWriteSeekStream.cs
@@ -24,12 +24,8 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace UnitTests.IO {
+namespace UnitTests.IO
+{
 	class CanReadWriteSeekStream : Stream
 	{
 		readonly bool read, write, seek, timeout;

--- a/UnitTests/IO/ChainedStreamTests.cs
+++ b/UnitTests/IO/ChainedStreamTests.cs
@@ -24,18 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 
-using NUnit.Framework;
-
-using MimeKit.IO;
 using MimeKit;
+using MimeKit.IO;
 
-namespace UnitTests.IO {
+namespace UnitTests.IO
+{
 	[TestFixture]
 	public class ChainedStreamTests
 	{

--- a/UnitTests/IO/FilteredStreamTests.cs
+++ b/UnitTests/IO/FilteredStreamTests.cs
@@ -24,17 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
-
 using MimeKit;
 using MimeKit.IO;
 using MimeKit.IO.Filters;
 
-namespace UnitTests.IO {
+namespace UnitTests.IO
+{
 	[TestFixture]
 	public class FilteredStreamTests
 	{

--- a/UnitTests/IO/Filters/FilterTests.cs
+++ b/UnitTests/IO/Filters/FilterTests.cs
@@ -24,19 +24,16 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
-using NUnit.Framework;
-
 using MimeKit;
+using MimeKit.Cryptography;
 using MimeKit.IO;
 using MimeKit.IO.Filters;
-using MimeKit.Cryptography;
 using MimeKit.Utils;
 
-namespace UnitTests.IO.Filters {
+namespace UnitTests.IO.Filters
+{
 	[TestFixture]
 	public class FilterTests
 	{

--- a/UnitTests/IO/MeasuringStreamTests.cs
+++ b/UnitTests/IO/MeasuringStreamTests.cs
@@ -24,15 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
-
 using MimeKit.IO;
 
-namespace UnitTests.IO {
+namespace UnitTests.IO
+{
 	[TestFixture]
 	public class MeasuringStreamTests
 	{

--- a/UnitTests/IO/MemoryBlockStreamTests.cs
+++ b/UnitTests/IO/MemoryBlockStreamTests.cs
@@ -24,17 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
-
 using MimeKit.IO;
 
-using System.Linq;
-
-namespace UnitTests.IO {
+namespace UnitTests.IO
+{
 	[TestFixture]
 	public class MemoryBlockStreamTests : IDisposable
 	{

--- a/UnitTests/IO/ReadOneByteStream.cs
+++ b/UnitTests/IO/ReadOneByteStream.cs
@@ -24,11 +24,8 @@
 // THE SOFTWARE.
 //
 
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace UnitTests.IO {
+namespace UnitTests.IO
+{
 	class ReadOneByteStream : Stream
 	{
 		readonly Stream source;

--- a/UnitTests/IO/TimeoutStream.cs
+++ b/UnitTests/IO/TimeoutStream.cs
@@ -24,37 +24,23 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace UnitTests.IO {
+namespace UnitTests.IO
+{
 	public class TimeoutStream : Stream
 	{
 		public TimeoutStream ()
 		{
 		}
 
-		public override bool CanRead {
-			get { return false; }
-		}
+		public override bool CanRead => false;
 
-		public override bool CanWrite {
-			get { return false; }
-		}
+		public override bool CanWrite => false;
 
-		public override bool CanSeek {
-			get { return false; }
-		}
+		public override bool CanSeek => false;
 
-		public override bool CanTimeout {
-			get { return true; }
-		}
+		public override bool CanTimeout => true;
 
-		public override long Length {
-			get { return 17; }
-		}
+		public override long Length => 17;
 
 		public override long Position {
 			get { return 15; }

--- a/UnitTests/InternetAddressListTests.cs
+++ b/UnitTests/InternetAddressListTests.cs
@@ -24,16 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-using System.Collections.Generic;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class InternetAddressListTests
 	{

--- a/UnitTests/InternetAddressTests.cs
+++ b/UnitTests/InternetAddressTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class InternetAddressTests
 	{

--- a/UnitTests/MailboxAddressTests.cs
+++ b/UnitTests/MailboxAddressTests.cs
@@ -24,18 +24,15 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.Text;
 using System.Globalization;
-using System.Collections.Generic;
-
-using NUnit.Framework;
+using System.Text;
 
 using MimeKit;
 using MimeKit.Cryptography;
 using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MailboxAddressTests
 	{

--- a/UnitTests/MessageDeliveryStatusTests.cs
+++ b/UnitTests/MessageDeliveryStatusTests.cs
@@ -24,16 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MessageDeliveryStatusTests
 	{

--- a/UnitTests/MessageDispositionNotificiationTests.cs
+++ b/UnitTests/MessageDispositionNotificiationTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MessageDispositionNotificiationTests
 	{

--- a/UnitTests/MessageFeedbackReportTests.cs
+++ b/UnitTests/MessageFeedbackReportTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MessageFeedbackReportTests
 	{

--- a/UnitTests/MessageIdListTests.cs
+++ b/UnitTests/MessageIdListTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Collections;
-
-using NUnit.Framework;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MessageIdListTests
 	{

--- a/UnitTests/MessagePartTests.cs
+++ b/UnitTests/MessagePartTests.cs
@@ -24,19 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Net.Mail;
-using System.Reflection;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
-
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MessagePartTests
 	{

--- a/UnitTests/MessagePartialTests.cs
+++ b/UnitTests/MessagePartialTests.cs
@@ -24,16 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Collections.Generic;
-
-using NUnit.Framework;
-
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MessagePartialTests
 	{

--- a/UnitTests/MimeContentTests.cs
+++ b/UnitTests/MimeContentTests.cs
@@ -24,18 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
-
 using MimeKit;
 
 using UnitTests.IO;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MimeContentTests
 	{

--- a/UnitTests/MimeIteratorTests.cs
+++ b/UnitTests/MimeIteratorTests.cs
@@ -24,14 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.Collections.Generic;
-
-using NUnit.Framework;
-
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MimeIteratorTests
 	{

--- a/UnitTests/MimeMessageTests.cs
+++ b/UnitTests/MimeMessageTests.cs
@@ -24,21 +24,16 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Net.Mail;
 using System.Reflection;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
+using System.Text;
 
 using MimeKit;
-using MimeKit.Utils;
 using MimeKit.Cryptography;
+using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MimeMessageTests
 	{

--- a/UnitTests/MimeParserTests.cs
+++ b/UnitTests/MimeParserTests.cs
@@ -24,25 +24,17 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Globalization;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-
-using NUnit.Framework;
-
-using Newtonsoft.Json;
 
 using MimeKit;
 using MimeKit.IO;
-using MimeKit.Utils;
 using MimeKit.IO.Filters;
+using MimeKit.Utils;
 
-namespace UnitTests {
+using Newtonsoft.Json;
+
+namespace UnitTests
+{
 	[TestFixture]
 	public class MimeParserTests
 	{

--- a/UnitTests/MimePartTests.cs
+++ b/UnitTests/MimePartTests.cs
@@ -24,12 +24,7 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Utils;

--- a/UnitTests/MimeReaderTests.cs
+++ b/UnitTests/MimeReaderTests.cs
@@ -24,20 +24,14 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
+using System.Text;
 
-using NUnit.Framework;
+using MimeKit;
 
 using Newtonsoft.Json;
 
-using MimeKit;
-using System.Text;
-
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MimeReaderTests
 	{

--- a/UnitTests/MimeTypeTests.cs
+++ b/UnitTests/MimeTypeTests.cs
@@ -24,13 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-
-using NUnit.Framework;
-
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MimeTypeTests
 	{

--- a/UnitTests/MimeVisitorTests.cs
+++ b/UnitTests/MimeVisitorTests.cs
@@ -24,18 +24,15 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Text;
 using System.Globalization;
-
-using NUnit.Framework;
+using System.Text;
 
 using MimeKit;
-using MimeKit.Tnef;
 using MimeKit.Cryptography;
+using MimeKit.Tnef;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MimeVisitorTests
 	{

--- a/UnitTests/MultipartAlternativeTests.cs
+++ b/UnitTests/MultipartAlternativeTests.cs
@@ -24,14 +24,11 @@
 // THE SOFTWARE.
 //
 
-using System;
-
-using NUnit.Framework;
-
 using MimeKit;
 using MimeKit.Text;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MultipartAlternativeTests
 	{

--- a/UnitTests/MultipartRelatedTests.cs
+++ b/UnitTests/MultipartRelatedTests.cs
@@ -24,16 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-
-using NUnit.Framework;
-
 using MimeKit;
 using MimeKit.Text;
 using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MultipartRelatedTests
 	{

--- a/UnitTests/MultipartReportTests.cs
+++ b/UnitTests/MultipartReportTests.cs
@@ -24,14 +24,11 @@
 // THE SOFTWARE.
 //
 
-using System;
-
-using NUnit.Framework;
-
 using MimeKit;
 using MimeKit.Text;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MultipartReportTests
 	{

--- a/UnitTests/MultipartTests.cs
+++ b/UnitTests/MultipartTests.cs
@@ -24,14 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-
-using NUnit.Framework;
-
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class MultipartTests
 	{

--- a/UnitTests/ParameterListTests.cs
+++ b/UnitTests/ParameterListTests.cs
@@ -24,15 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.Text;
 using System.Collections;
-
-using NUnit.Framework;
+using System.Text;
 
 using MimeKit;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class ParameterListTests
 	{

--- a/UnitTests/ParameterTests.cs
+++ b/UnitTests/ParameterTests.cs
@@ -24,15 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class ParameterTests
 	{

--- a/UnitTests/ParserOptionsTests.cs
+++ b/UnitTests/ParserOptionsTests.cs
@@ -24,12 +24,7 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
 
 using MimeKit;
 

--- a/UnitTests/TestHelper.cs
+++ b/UnitTests/TestHelper.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit.Utils;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[SetUpFixture]
 	static class TestHelper
 	{

--- a/UnitTests/Text/FlowedToHtmlTests.cs
+++ b/UnitTests/Text/FlowedToHtmlTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class FlowedToHtmlTests
 	{

--- a/UnitTests/Text/FlowedToTextTests.cs
+++ b/UnitTests/Text/FlowedToTextTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class FlowedToTextTests
 	{

--- a/UnitTests/Text/HtmlAttributeCollectionTests.cs
+++ b/UnitTests/Text/HtmlAttributeCollectionTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Collections;
-
-using NUnit.Framework;
 
 using MimeKit.Text;
 
-namespace UnitTests {
+namespace UnitTests
+{
 	[TestFixture]
 	public class HtmlAttributeCollectionTests
 	{

--- a/UnitTests/Text/HtmlAttributeTests.cs
+++ b/UnitTests/Text/HtmlAttributeTests.cs
@@ -24,13 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-
-using NUnit.Framework;
-
 using MimeKit.Text;
 
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class HtmlAttributeTests
 	{

--- a/UnitTests/Text/HtmlEntityDecoderTests.cs
+++ b/UnitTests/Text/HtmlEntityDecoderTests.cs
@@ -24,14 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System.IO;
-
-using NUnit.Framework;
-
-using Newtonsoft.Json;
 using MimeKit.Text;
 
-namespace UnitTests.Text {
+using Newtonsoft.Json;
+
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class HtmlEntityDecoderTests
 	{

--- a/UnitTests/Text/HtmlTagIdTests.cs
+++ b/UnitTests/Text/HtmlTagIdTests.cs
@@ -26,9 +26,8 @@
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class HtmlTagIdTests
 	{

--- a/UnitTests/Text/HtmlTextPreviewerTests.cs
+++ b/UnitTests/Text/HtmlTextPreviewerTests.cs
@@ -24,16 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
-using MimeKit;
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class HtmlTextPreviewerTests
 	{

--- a/UnitTests/Text/HtmlToHtmlTests.cs
+++ b/UnitTests/Text/HtmlToHtmlTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class HtmlToHtmlTests
 	{

--- a/UnitTests/Text/HtmlTokenTests.cs
+++ b/UnitTests/Text/HtmlTokenTests.cs
@@ -24,11 +24,7 @@
 // THE SOFTWARE.
 //
 
-using System;
-
 using MimeKit.Text;
-
-using NUnit.Framework;
 
 namespace UnitTests.Text
 {

--- a/UnitTests/Text/HtmlTokenizerTests.cs
+++ b/UnitTests/Text/HtmlTokenizerTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class HtmlTokenizerTests
 	{

--- a/UnitTests/Text/HtmlUtilsTests.cs
+++ b/UnitTests/Text/HtmlUtilsTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit.Text;
 
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class HtmlUtilsTests
 	{

--- a/UnitTests/Text/HtmlWriterTests.cs
+++ b/UnitTests/Text/HtmlWriterTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit.Text;
 
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class HtmlWriterTests
 	{

--- a/UnitTests/Text/PlainTextPreviewerTests.cs
+++ b/UnitTests/Text/PlainTextPreviewerTests.cs
@@ -24,16 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
-using MimeKit;
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class PlainTextPreviewerTests
 	{

--- a/UnitTests/Text/RtfCompressedToRtfTests.cs
+++ b/UnitTests/Text/RtfCompressedToRtfTests.cs
@@ -24,16 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
-using MimeKit.IO;
 using MimeKit.Tnef;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class RtfCompressedToRtfTests
 	{

--- a/UnitTests/Text/TextConverterTests.cs
+++ b/UnitTests/Text/TextConverterTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class TextConverterTests
 	{

--- a/UnitTests/Text/TextPreviewerTests.cs
+++ b/UnitTests/Text/TextPreviewerTests.cs
@@ -24,16 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit;
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class TextPreviewerTests
 	{

--- a/UnitTests/Text/TextToFlowedTests.cs
+++ b/UnitTests/Text/TextToFlowedTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class TextToFlowedTests
 	{

--- a/UnitTests/Text/TextToHtmlTests.cs
+++ b/UnitTests/Text/TextToHtmlTests.cs
@@ -24,16 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit.Encodings;
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class TextToHtmlTests
 	{

--- a/UnitTests/Text/TextToTextTests.cs
+++ b/UnitTests/Text/TextToTextTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class TextToTextTests
 	{

--- a/UnitTests/Text/TrieTests.cs
+++ b/UnitTests/Text/TrieTests.cs
@@ -24,13 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class TrieTests
 	{

--- a/UnitTests/Text/UrlScannerTests.cs
+++ b/UnitTests/Text/UrlScannerTests.cs
@@ -26,9 +26,8 @@
 
 using MimeKit.Text;
 
-using NUnit.Framework;
-
-namespace UnitTests.Text {
+namespace UnitTests.Text
+{
 	[TestFixture]
 	public class UrlScannerTests
 	{

--- a/UnitTests/TextPartTests.cs
+++ b/UnitTests/TextPartTests.cs
@@ -24,11 +24,7 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Text;

--- a/UnitTests/TextRfc822HeadersTests.cs
+++ b/UnitTests/TextRfc822HeadersTests.cs
@@ -24,11 +24,6 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-
-using NUnit.Framework;
-
 using MimeKit;
 
 namespace UnitTests

--- a/UnitTests/Tnef/RtfCompressedToRtfTests.cs
+++ b/UnitTests/Tnef/RtfCompressedToRtfTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit.Tnef;
 
-namespace UnitTests.Tnef {
+namespace UnitTests.Tnef
+{
 	[TestFixture]
 	public class RtfCompressedToRtfTests
 	{

--- a/UnitTests/Tnef/TnefReaderStreamTests.cs
+++ b/UnitTests/Tnef/TnefReaderStreamTests.cs
@@ -24,14 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-
-using NUnit.Framework;
-
 using MimeKit.Tnef;
 
-namespace UnitTests.Tnef {
+namespace UnitTests.Tnef
+{
 	[TestFixture]
 	public class TnefReaderStreamTests
 	{

--- a/UnitTests/Tnef/TnefReaderTests.cs
+++ b/UnitTests/Tnef/TnefReaderTests.cs
@@ -24,14 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-
-using NUnit.Framework;
-
 using MimeKit.Tnef;
 
-namespace UnitTests.Tnef {
+namespace UnitTests.Tnef
+{
 	[TestFixture]
 	public class TnefReaderTests
 	{

--- a/UnitTests/Tnef/TnefTests.cs
+++ b/UnitTests/Tnef/TnefTests.cs
@@ -24,21 +24,17 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-using System.Text;
-using System.Linq;
 using System.Globalization;
+using System.Text;
 
 using MimeKit;
 using MimeKit.IO;
+using MimeKit.IO.Filters;
 using MimeKit.Tnef;
 using MimeKit.Utils;
-using MimeKit.IO.Filters;
 
-using NUnit.Framework;
-
-namespace UnitTests.Tnef {
+namespace UnitTests.Tnef
+{
 	[TestFixture]
 	public class TnefTests
 	{

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -9,6 +9,7 @@
     <DefineConstants Condition=" '$(MonoRuntime)' == 'true' ">$(DefineConstants);MONO</DefineConstants>
     <AssemblyOriginatorKeyFile>..\MimeKit\mimekit.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
 
     <SQLiteRuntime>win-x64</SQLiteRuntime>
     <SQLiteRuntime Condition=" '$(MonoRuntime)' == 'true' ">linux-x64</SQLiteRuntime>
@@ -17,6 +18,10 @@
 
   <ItemGroup>
     <Reference Include="System.Security" Condition=" $(TargetFramework.StartsWith('net4')) " />
+  </ItemGroup>
+	
+  <ItemGroup>
+     <Using Include="NUnit.Framework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Utils/CharsetUtilsTests.cs
+++ b/UnitTests/Utils/CharsetUtilsTests.cs
@@ -24,15 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests.Utils {
+namespace UnitTests.Utils
+{
 	[TestFixture]
 	public class CharsetUtilsTests
 	{

--- a/UnitTests/Utils/DateParserTests.cs
+++ b/UnitTests/Utils/DateParserTests.cs
@@ -24,13 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-using NUnit.Framework;
 
 using MimeKit.Utils;
 
-namespace UnitTests.Utils {
+namespace UnitTests.Utils
+{
 	[TestFixture]
 	public class DateParserTests
 	{

--- a/UnitTests/Utils/MimeUtilsTests.cs
+++ b/UnitTests/Utils/MimeUtilsTests.cs
@@ -24,15 +24,12 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.Linq;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit.Utils;
 
-namespace UnitTests.Utils {
+namespace UnitTests.Utils
+{
 	[TestFixture]
 	public class MimeUtilsTests
 	{

--- a/UnitTests/Utils/PackedByteArrayTests.cs
+++ b/UnitTests/Utils/PackedByteArrayTests.cs
@@ -24,13 +24,10 @@
 // THE SOFTWARE.
 //
 
-using System;
-
-using NUnit.Framework;
-
 using MimeKit.Utils;
 
-namespace UnitTests.Utils {
+namespace UnitTests.Utils
+{
 	[TestFixture]
 	public class PackedByteArrayTests
 	{

--- a/UnitTests/Utils/ParseUtilsTests.cs
+++ b/UnitTests/Utils/ParseUtilsTests.cs
@@ -24,15 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests.Utils {
+namespace UnitTests.Utils
+{
 	[TestFixture]
 	public class ParseUtilsTests
 	{

--- a/UnitTests/Utils/Rfc2047Tests.cs
+++ b/UnitTests/Utils/Rfc2047Tests.cs
@@ -24,15 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests.Utils {
+namespace UnitTests.Utils
+{
 	[TestFixture]
 	public class Rfc2047Tests
 	{

--- a/UnitTests/Utils/StringBuilderExtensionTests.cs
+++ b/UnitTests/Utils/StringBuilderExtensionTests.cs
@@ -24,16 +24,13 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Text;
-using System.Collections.Generic;
-
-using NUnit.Framework;
 
 using MimeKit;
 using MimeKit.Utils;
 
-namespace UnitTests.Utils {
+namespace UnitTests.Utils
+{
 	[TestFixture]
 	public class StringBuilderExtensionTests
 	{

--- a/UnitTests/Utils/ValueStringBuilderTests.cs
+++ b/UnitTests/Utils/ValueStringBuilderTests.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Text;
-
-using NUnit.Framework;
 
 using MimeKit.Utils;
 


### PR DESCRIPTION
This PR enables implicit usings on the test project.

NOTE: the bracing style is inconsistent within the test project. Most files in UnitTests.Cryptography have the brace on a new line -- a few updates were made to make the bracing style consistent within the file.

We may also consider updating the test project to use file-scoped namespaces to remove this inconsistency all together.