### PR TITLE
Add a type converter for the InternetAddress type

### DIFF
--- a/MimeKit/InternetAddress.cs
+++ b/MimeKit/InternetAddress.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // InternetAddress.cs
 //
 // Author: Jeffrey Stedfast <jestedfa@microsoft.com>
@@ -27,6 +27,7 @@
 using System;
 using System.Text;
 using System.Globalization;
+using System.ComponentModel;
 
 using MimeKit.Utils;
 
@@ -45,6 +46,7 @@ namespace MimeKit {
 	/// types of addresses. They typically only contain mailbox addresses, but may also
 	/// contain other group addresses.</para>
 	/// </remarks>
+	[TypeConverter(typeof(InternetAddressTypeConverter))]
 	public abstract class InternetAddress : IComparable<InternetAddress>, IEquatable<InternetAddress>
 	{
 		const string AtomSpecials = "()<>@,;:\\\".[]";

--- a/MimeKit/InternetAddressList.cs
+++ b/MimeKit/InternetAddressList.cs
@@ -28,6 +28,7 @@ using System;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 #if ENABLE_SNM
 using System.Net.Mail;
@@ -50,6 +51,7 @@ namespace MimeKit {
 	/// types of addresses. They typically only contain mailbox addresses, but may also
 	/// contain other group addresses.</para>
 	/// </remarks>
+	[TypeConverter(typeof(InternetAddressListTypeConverter))]
 	public class InternetAddressList : IList<InternetAddress>, IEquatable<InternetAddressList>, IComparable<InternetAddressList>
 	{
 		readonly List<InternetAddress> list = new List<InternetAddress> ();

--- a/MimeKit/InternetAddressListTypeConverter.cs
+++ b/MimeKit/InternetAddressListTypeConverter.cs
@@ -1,0 +1,80 @@
+//
+// InternetAddressListTypeConverter.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2023 .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Threading;
+
+namespace MimeKit {
+	/// <summary>
+	/// Provides a way of converting <see cref="InternetAddressList"/> from and to string.
+	/// </summary>
+	public class InternetAddressListTypeConverter : TypeConverter
+	{
+		private static ParserOptions _parserOptions;
+
+		/// <summary>
+		/// Register the type converter so that it's available through <c>TypeDescriptor.GetConverter(typeof(InternetAddressList))</c>.
+		/// </summary>
+		/// <param name="parserOptions">The <see cref="ParserOptions"/> to use when converting from string or <see langword="null"/> to use the default options.</param>
+		/// <exception cref="InvalidOperationException">The Register method is called more than once.</exception>
+		public static void Register (ParserOptions parserOptions = null)
+		{
+			if (Interlocked.Exchange (ref _parserOptions, parserOptions ?? ParserOptions.Default) != null) {
+				throw new InvalidOperationException ($"The {typeof(InternetAddressListTypeConverter)}.{nameof(Register)} method must be called only once.");
+			}
+
+			TypeDescriptor.AddAttributes (typeof(InternetAddressList), new TypeConverterAttribute (typeof(InternetAddressListTypeConverter)));
+		}
+
+		/// <inheritdoc/>
+		public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
+		{
+			return sourceType == typeof(string) || base.CanConvertFrom (context, sourceType);
+		}
+
+		/// <inheritdoc/>
+		public override object ConvertFrom (ITypeDescriptorContext context, CultureInfo culture, object value)
+		{
+			if (value is string text) {
+				return InternetAddressList.Parse (_parserOptions ?? ParserOptions.Default, text);
+			}
+
+			return base.ConvertFrom (context, culture, value);
+		}
+
+		/// <inheritdoc/>
+		public override bool IsValid (ITypeDescriptorContext context, object value)
+		{
+			if (value is string text) {
+				return InternetAddressList.TryParse (_parserOptions ?? ParserOptions.Default, text, out _);
+			}
+
+			return base.IsValid (context, value);
+		}
+	}
+}

--- a/MimeKit/InternetAddressTypeConverter.cs
+++ b/MimeKit/InternetAddressTypeConverter.cs
@@ -1,0 +1,80 @@
+//
+// InternetAddressTypeConverter.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2023 .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Threading;
+
+namespace MimeKit {
+	/// <summary>
+	/// Provides a way of converting <see cref="InternetAddress"/> from and to string.
+	/// </summary>
+	public class InternetAddressTypeConverter : TypeConverter
+	{
+		private static ParserOptions _parserOptions;
+
+		/// <summary>
+		/// Register the type converter so that it's available through <c>TypeDescriptor.GetConverter(typeof(InternetAddress))</c>.
+		/// </summary>
+		/// <param name="parserOptions">The <see cref="ParserOptions"/> to use when converting from string or <see langword="null"/> to use the default options.</param>
+		/// <exception cref="InvalidOperationException">The Register method is called more than once.</exception>
+		public static void Register (ParserOptions parserOptions = null)
+		{
+			if (Interlocked.Exchange (ref _parserOptions, parserOptions ?? ParserOptions.Default) != null) {
+				throw new InvalidOperationException ($"The {typeof(InternetAddressTypeConverter)}.{nameof(Register)} method must be called only once.");
+			}
+
+			TypeDescriptor.AddAttributes (typeof(InternetAddress), new TypeConverterAttribute (typeof(InternetAddressTypeConverter)));
+		}
+
+		/// <inheritdoc/>
+		public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
+		{
+			return sourceType == typeof(string) || base.CanConvertFrom (context, sourceType);
+		}
+
+		/// <inheritdoc/>
+		public override object ConvertFrom (ITypeDescriptorContext context, CultureInfo culture, object value)
+		{
+			if (value is string text) {
+				return InternetAddress.Parse (_parserOptions ?? ParserOptions.Default, text);
+			}
+
+			return base.ConvertFrom (context, culture, value);
+		}
+
+		/// <inheritdoc/>
+		public override bool IsValid (ITypeDescriptorContext context, object value)
+		{
+			if (value is string text) {
+				return InternetAddress.TryParse (_parserOptions ?? ParserOptions.Default, text, out _);
+			}
+
+			return base.IsValid (context, value);
+		}
+	}
+}

--- a/UnitTests/InternetAddressListTypeConverterTests.cs
+++ b/UnitTests/InternetAddressListTypeConverterTests.cs
@@ -1,0 +1,76 @@
+//
+// InternetAddressListTypeConverterTests.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2023 .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System.ComponentModel;
+using System.Linq;
+
+using NUnit.Framework;
+
+using MimeKit;
+
+namespace UnitTests;
+
+[TestFixture]
+public class InternetAddressListTypeConverterTests
+{
+	[Test]
+	public void TestCanConvert ()
+	{
+		var converter = TypeDescriptor.GetConverter (typeof(InternetAddressList));
+		Assert.True (converter.CanConvertFrom (typeof(string)));
+		Assert.True (converter.CanConvertTo (typeof(string)));
+	}
+
+	[Test]
+	public void TestIsValid ()
+	{
+		var converter = TypeDescriptor.GetConverter (typeof(InternetAddressList));
+		Assert.True (converter.IsValid ("Skye <skye@shield.gov>, Leo Fitz <fitz@shield.gov>, Melinda May <may@shield.gov>"));
+	}
+
+	[Test]
+	public void TestConvertFromValid ()
+	{
+		var converter = TypeDescriptor.GetConverter (typeof(InternetAddressList));
+		var result = converter.ConvertFrom ("Skye <skye@shield.gov>, Leo Fitz <fitz@shield.gov>, Melinda May <may@shield.gov>");
+		Assert.IsInstanceOf<InternetAddressList> (result);
+		Assert.AreEqual (new[] { "Skye", "Leo Fitz", "Melinda May" }, ((InternetAddressList)result).Select (e => e.Name));
+	}
+
+	[Test]
+	public void TestIsNotValid ()
+	{
+		var converter = TypeDescriptor.GetConverter (typeof(InternetAddressList));
+		Assert.False (converter.IsValid (""));
+	}
+
+	[Test]
+	public void TestConvertFromNotValid ()
+	{
+		var converter = TypeDescriptor.GetConverter (typeof(InternetAddressList));
+		Assert.Throws<ParseException> (() => converter.ConvertFrom (""));
+	}
+}

--- a/UnitTests/InternetAddressTypeConverterTests.cs
+++ b/UnitTests/InternetAddressTypeConverterTests.cs
@@ -1,0 +1,76 @@
+﻿//
+// InternetAddressTypeConverterTests.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2023 .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System.ComponentModel;
+
+using NUnit.Framework;
+
+using MimeKit;
+
+namespace UnitTests {
+	[TestFixture]
+	public class InternetAddressTypeConverterTests
+	{
+		[Test]
+		public void TestCanConvert ()
+		{
+			var converter = TypeDescriptor.GetConverter (typeof(InternetAddress));
+			Assert.True (converter.CanConvertFrom (typeof(string)));
+			Assert.True (converter.CanConvertTo (typeof(string)));
+		}
+
+		[Test]
+		public void TestIsValid ()
+		{
+			var converter = TypeDescriptor.GetConverter (typeof(InternetAddress));
+			Assert.True (converter.IsValid ("Jeffrey Stedfast <jestedfa@microsoft.com>"));
+		}
+
+		[Test]
+		public void TestConvertFromValid ()
+		{
+			var converter = TypeDescriptor.GetConverter (typeof(InternetAddress));
+			var result = converter.ConvertFrom ("Jeffrey Stedfast <jestedfa@microsoft.com>");
+			Assert.IsInstanceOf<MailboxAddress> (result);
+			Assert.AreEqual ("Jeffrey Stedfast", ((MailboxAddress)result).Name);
+			Assert.AreEqual ("jestedfa@microsoft.com", ((MailboxAddress)result).Address);
+		}
+
+		[Test]
+		public void TestIsNotValid ()
+		{
+			var converter = TypeDescriptor.GetConverter (typeof(InternetAddress));
+			Assert.False (converter.IsValid (""));
+		}
+
+		[Test]
+		public void TestConvertFromNotValid ()
+		{
+			var converter = TypeDescriptor.GetConverter (typeof(InternetAddress));
+			Assert.Throws<ParseException> (() => converter.ConvertFrom (""));
+		}
+	}
+}


### PR DESCRIPTION
This is useful to automatically convert strings to typed InternetAddress subclasses. For example, when using the `Microsoft.Extensions.Configuration` package.