### PR TITLE
Do not encode unstructured headers if not needed

### DIFF
--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using System.Linq;
 
 using MimeKit.Utils;
 using MimeKit.Cryptography;
@@ -1097,9 +1098,22 @@ namespace MimeKit {
 				return Encoding.UTF8.GetBytes (folded);
 			}
 
+			if (IsAsciiOnlyWithoutCrLf (value)) {
+				return Encoding.ASCII.GetBytes (value);
+			}
+
 			var encoded = Rfc2047.EncodeText (format, encoding, value);
 
 			return Rfc2047.FoldUnstructuredHeader (format, field, encoded);
+		}
+
+		static bool IsAsciiOnlyWithoutCrLf (string value)
+		{
+#if NET6_0_OR_GREATER
+			return value.All (c => char.IsAscii (c) && c != '\r' && c != '\n');
+#else
+			return value.All (c => c < 128 && c != '\r' && c != '\n');
+#endif
 		}
 
 		/// <summary>

--- a/UnitTests/HeaderTests.cs
+++ b/UnitTests/HeaderTests.cs
@@ -654,5 +654,40 @@ namespace UnitTests {
 
 			Assert.AreEqual (expected, result);
 		}
+
+
+		[Test]
+		public void TestAsciiOnlyLongUnstructuredHeader ()
+		{
+			const string headerValue = "<https://www.some-link.com/query-params?abcd=efgh&this=is-very-long-string-which-should-not-be-Rfc2047-encoded-and-should-be-kept-the-way-it-is-by-default>";
+			var expected = Encoding.ASCII.GetBytes (headerValue);
+			var header = new Header ("List-Unsubscribe", headerValue);
+
+			var options = FormatOptions.Default.Clone ();
+			options.NewLineFormat = NewLineFormat.Dos;
+			options.International = false;
+
+			var result = header.GetRawValue (options);
+
+			Assert.AreEqual (expected, result);
+		}
+
+		[Test]
+		public void TestUtf8UnstructuredHeader ()
+		{
+			const string headerValue = "ěščřžýáíé";
+			var expectedString = " =?utf-8?b?xJvFocSNxZnFvsO9w6HDrcOp?=\r\n";
+			var expected = Encoding.ASCII.GetBytes (expectedString);
+			var header = new Header ("List-Unsubscribe", headerValue);
+
+			var options = FormatOptions.Default.Clone ();
+			options.NewLineFormat = NewLineFormat.Dos;
+			options.International = false;
+
+			var result = header.GetRawValue (options);
+			var str = Encoding.ASCII.GetString (result);
+
+			Assert.AreEqual (expected, result);
+		}
 	}
 }


### PR DESCRIPTION
Hello,

this PR updates handling of unstructured headers to better follow [RFC2822](https://www.rfc-editor.org/rfc/rfc2822#section-2.2.1) 
which states the following statement:

> Some field bodies in this standard are defined simply as
   "unstructured" (which is specified below as any US-ASCII characters,
   except for CR and LF) with no further restrictions.  These are
   referred to as unstructured field bodies.  Semantically, unstructured
   field bodies are simply to be treated as a single line of characters
   with no further processing (except for header "folding" and
   "unfolding" as described in [section 2.2.3](https://www.rfc-editor.org/rfc/rfc2822#section-2.2.3)).
> 

Reason for this PR is some email clients are unable to process for example the `Unsubscribe-List` header with Q-Encoded values (for example Thunderbird and eM Client).

Encoding unstructured headers by Rfc2047 only when they contain non-ASCII characters fixes this problem.
