### PR TITLE
Optimize sentinel checks

### DIFF
--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -608,8 +608,8 @@ namespace MimeKit {
 				index++;
 		}
 
-		static readonly byte[] ReceivedAddrSpecSentinels = { (byte) '>', (byte) ';' };
-		static readonly byte[] ReceivedMessageIdSentinels = { (byte) '>' };
+		static ReadOnlySpan<byte> ReceivedAddrSpecSentinels => new[] { (byte) '>', (byte) ';' };
+		static ReadOnlySpan<byte> ReceivedMessageIdSentinels => new[] { (byte) '>' };
 
 		static void ReceivedTokenSkipAddress (byte[] text, ref int index)
 		{

--- a/MimeKit/InternetAddress.cs
+++ b/MimeKit/InternetAddress.cs
@@ -27,7 +27,6 @@
 using System;
 using System.Text;
 using System.Globalization;
-using System.Collections.Generic;
 
 using MimeKit.Utils;
 
@@ -370,9 +369,9 @@ namespace MimeKit {
 			return true;
 		}
 
-		static readonly byte[] CommaGreaterThanOrSemiColon = { (byte) ',', (byte) '>', (byte) ';' };
+		static ReadOnlySpan<byte> CommaGreaterThanOrSemiColon => new[] { (byte) ',', (byte) '>', (byte) ';' };
 
-		internal static bool TryParseAddrspec (byte[] text, ref int index, int endIndex, byte[] sentinels, RfcComplianceMode compliance, bool throwOnError, out string addrspec, out int at)
+		internal static bool TryParseAddrspec (byte[] text, ref int index, int endIndex, ReadOnlySpan<byte> sentinels, RfcComplianceMode compliance, bool throwOnError, out string addrspec, out int at)
 		{
 			int startIndex = index;
 

--- a/MimeKit/Utils/ParseUtils.cs
+++ b/MimeKit/Utils/ParseUtils.cs
@@ -31,8 +31,6 @@ using System.Globalization;
 namespace MimeKit.Utils {
 	static class ParseUtils
 	{
-		static readonly IdnMapping idn = new IdnMapping ();
-
 		public static void ValidateArguments (ParserOptions options, byte[] buffer, int startIndex, int length)
 		{
 			if (options is null)

--- a/MimeKit/Utils/ParseUtils.cs
+++ b/MimeKit/Utils/ParseUtils.cs
@@ -274,7 +274,7 @@ namespace MimeKit.Utils {
 			return false;
 		}
 
-		public static bool IsSentinel (byte c, byte[] sentinels)
+		public static bool IsSentinel (byte c, ReadOnlySpan<byte> sentinels)
 		{
 			for (int i = 0; i < sentinels.Length; i++) {
 				if (c == sentinels[i])
@@ -284,7 +284,7 @@ namespace MimeKit.Utils {
 			return false;
 		}
 
-		static bool TryParseDotAtom (byte[] text, ref int index, int endIndex, byte[] sentinels, bool throwOnError, string tokenType, out string dotatom)
+		static bool TryParseDotAtom (byte[] text, ref int index, int endIndex, ReadOnlySpan<byte> sentinels, bool throwOnError, string tokenType, out string dotatom)
 		{
 			using var token = new ValueStringBuilder (128);
 			int startIndex = index;
@@ -384,7 +384,7 @@ namespace MimeKit.Utils {
 			return true;
 		}
 
-		public static bool TryParseDomain (byte[] text, ref int index, int endIndex, byte[] sentinels, bool throwOnError, out string domain)
+		public static bool TryParseDomain (byte[] text, ref int index, int endIndex, ReadOnlySpan<byte> sentinels, bool throwOnError, out string domain)
 		{
 			if (text[index] == (byte) '[')
 				return TryParseDomainLiteral (text, ref index, endIndex, throwOnError, out domain);
@@ -392,11 +392,11 @@ namespace MimeKit.Utils {
 			return TryParseDotAtom (text, ref index, endIndex, sentinels, throwOnError, "domain", out domain);
 		}
 
-		static readonly byte[] GreaterThanOrAt = { (byte) '>', (byte) '@' };
+		static ReadOnlySpan<byte> GreaterThanOrAt => new[] { (byte) '>', (byte) '@' };
 
 		public static bool TryParseMsgId (byte[] text, ref int index, int endIndex, bool requireAngleAddr, bool throwOnError, out string msgid)
 		{
-			//const CharType SpaceOrControl = CharType.IsWhitespace | CharType.IsControl;
+			// const CharType SpaceOrControl = CharType.IsWhitespace | CharType.IsControl;
 			var angleAddr = false;
 
 			msgid = null;


### PR DESCRIPTION
Replaces a few mutable arrays with statically initialized readonly spans and removes an unused property.

@jstedfast ready for review.