### PR TITLE
Not parsing address headers in Looser RfcComplianceMode

### DIFF
--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -557,7 +557,7 @@ namespace MimeKit {
 
 		static byte[] EncodeAddressHeader (ParserOptions options, FormatOptions format, Encoding encoding, string field, string value)
 		{
-			if (!InternetAddressList.TryParse (options, value, out var list))
+			if (options.AddressParserComplianceMode == RfcComplianceMode.Looser || !InternetAddressList.TryParse (options, value, out var list))
 				return EncodeUnstructuredHeader (options, format, encoding, field, value);
 
 			var encoded = new StringBuilder (" ");


### PR DESCRIPTION
Would it have sense to have such "feature"? We have some memory problems when processing TO header with 80k addressees. It is not important for us to do any analysis what's inside and parse all participants.