### PR TITLE
Modified Rfc2047's internal Token class to be a struct

### DIFF
--- a/MimeKit/Utils/ValueList.cs
+++ b/MimeKit/Utils/ValueList.cs
@@ -1,0 +1,70 @@
+﻿//
+// ValueList.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2023 .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace MimeKit.Utils {
+	ref struct ValueList<T>
+	{
+		T[] array;
+		int count;
+
+		public ValueList (int capacity)
+		{
+			array = ArrayPool<T>.Shared.Rent (capacity);
+			count = 0;
+		}
+
+		public int Count { get { return count; } }
+
+		public T this[int index] { get { return array[index]; } }
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		void EnsureCapacity (int capacity)
+		{
+			if (capacity > array.Length) {
+				var resized = ArrayPool<T>.Shared.Rent (capacity);
+				Array.Copy (array, 0, resized, 0, count);
+				ArrayPool<T>.Shared.Return (array);
+				array = resized;
+			}
+		}
+
+		public void Add (T item)
+		{
+			EnsureCapacity (count + 1);
+			array[count++] = item;
+		}
+
+		public void Dispose ()
+		{
+			ArrayPool<T>.Shared.Return (array);
+			count = 0;
+		}
+	}
+}


### PR DESCRIPTION
This reduces the number of allocations needed, but it does mean that List<Token> will be much larger.

To combat this a bit, redesigned the Token class/struct to have fewer fields which reduced sizeof(Token) from 40 bytes down to 24.

Ideally, we'd get that down even further to 16 bytes (as recommended by Microsoft). Added some comments with ideas on how to accomplish that.