### PR TITLE
WIP: `FormatOptions`: Feature `ConvertPunycodeToIdn`

### DIFF
--- a/MimeKit/FormatOptions.cs
+++ b/MimeKit/FormatOptions.cs
@@ -83,6 +83,7 @@ namespace MimeKit {
 		bool verifyingSignature;
 		bool ensureNewLine;
 		bool international;
+		bool convertPunycodeToIdn;
 		int maxLineLength;
 
 		/// <summary>
@@ -243,6 +244,15 @@ namespace MimeKit {
 		}
 
 		/// <summary>
+		/// Get or set whether to convert punycode domains.
+		/// </summary>
+		/// <value><c>true</c> if punycoded domains should be converted to IDN; otherwise, <c>false</c>.</value>
+		public bool ConvertPunycodeToIdn {
+			get { return convertPunycodeToIdn; }
+			set { convertPunycodeToIdn = value; }
+		}
+
+		/// <summary>
 		/// Get or set whether the formatter should allow mixed charsets in the headers.
 		/// </summary>
 		/// <remarks>
@@ -344,6 +354,7 @@ namespace MimeKit {
 			allowMixedHeaderCharsets = false;
 			ensureNewLine = false;
 			international = false;
+			convertPunycodeToIdn = true;
 
 			if (Environment.NewLine.Length == 1)
 				newLineFormat = NewLineFormat.Unix;
@@ -369,7 +380,8 @@ namespace MimeKit {
 				parameterEncodingMethod = parameterEncodingMethod,
 				alwaysQuoteParameterValues = alwaysQuoteParameterValues,
 				verifyingSignature = verifyingSignature,
-				international = international
+				international = international,
+				convertPunycodeToIdn = convertPunycodeToIdn
 			};
 		}
 	}

--- a/UnitTests/MailboxAddressTests.cs
+++ b/UnitTests/MailboxAddressTests.cs
@@ -479,6 +479,17 @@ namespace UnitTests {
 		}
 
 		[Test]
+		public void TestParseIdnPunycodeAddress ()
+		{
+			const string encoded = "user@xn--v8jxj3d1dzdz08w.com";
+			MailboxAddress mailbox;
+			ParserOptions options = new () { convertPunycodeToIdn = false };
+
+			Assert.That (MailboxAddress.TryParse (options, encoded, out mailbox), Is.True);
+			Assert.That (mailbox.Address, Is.EqualTo (encoded));
+		}
+
+		[Test]
 		public void TestParseAddrspecNoAtDomain ()
 		{
 			const string text = "jeff";


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
A lot of places requires working with punycoded mails as the IDN form is not handled correctly.
But when parsing, mails are turned into IDN form, i.e. `MimeKit.MailboxAddress.Parse("X@xn--sb-lka.org").Address == "X@søb.org"`

**Describe the solution you'd like**
It would be nice with an option to keep the address in punycoded form.

**Describe alternatives you've considered**
I guess users of this library can also do something like:
```C#
if (mailbox.IsInternational)
    mail = mailbox.LocalPart + "@" + MailboxAddress.IdnMapping.Encode(mailbox.Domain)
```

**Additional context**
This is a suggestion for adding that. Comments are welcome!