### PR TITLE
Enable nullable reference types for some header related classes

### DIFF
--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -24,9 +24,20 @@
 // THE SOFTWARE.
 //
 
+#nullable enable
+
+#if !NET5_0_OR_GREATER
+// MemberNotNull attribute is not available below net5.0
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#endif
+
+
 using System;
 using System.Text;
 using System.Collections.Generic;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Runtime.CompilerServices;
 
 using MimeKit.Utils;
@@ -53,7 +64,7 @@ namespace MimeKit {
 
 		readonly byte[] rawField;
 		bool explicitRawValue;
-		string textValue;
+		string? textValue;
 		byte[] rawValue;
 
 		/// <summary>
@@ -678,7 +689,7 @@ namespace MimeKit {
 			int count = 0;
 
 			while (index < rawValue.Length) {
-				ReceivedTokenValue token = null;
+				ReceivedTokenValue? token = null;
 				int startIndex = index;
 
 				if (!ParseUtils.SkipCommentsAndWhiteSpace (rawValue, ref index, rawValue.Length, false) || index >= rawValue.Length) {
@@ -1443,6 +1454,9 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="value"/> is <see langword="null"/>.</para>
 		/// </exception>
+#if NET5_0_OR_GREATER
+		[MemberNotNull(nameof(rawValue))]
+#endif
 		public void SetValue (FormatOptions format, Encoding encoding, string value)
 		{
 			if (format is null)
@@ -1483,6 +1497,9 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="value"/> is <see langword="null"/>.</para>
 		/// </exception>
+#if NET5_0_OR_GREATER
+		[MemberNotNull (nameof (rawValue))]
+#endif
 		public void SetValue (Encoding encoding, string value)
 		{
 			SetValue (FormatOptions.Default, encoding, value);
@@ -1575,7 +1592,7 @@ namespace MimeKit {
 			OnChanged ();
 		}
 
-		internal event EventHandler Changed;
+		internal event EventHandler? Changed;
 
 		void OnChanged ()
 		{
@@ -1655,7 +1672,11 @@ namespace MimeKit {
 			return c.IsBlank ();
 		}
 
-		internal static unsafe bool TryParse (ParserOptions options, byte* input, int length, bool strict, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		internal static unsafe bool TryParse (ParserOptions options, byte* input, int length, bool strict, [NotNullWhen(true)] out Header? header)
+#else
+		internal static unsafe bool TryParse (ParserOptions options, byte* input, int length, bool strict, out Header? header)
+#endif
 		{
 			byte* inend = input + length;
 			byte* start = input;
@@ -1749,7 +1770,11 @@ namespace MimeKit {
 		/// <paramref name="startIndex"/> and <paramref name="length"/> do not specify
 		/// a valid range in the byte array.
 		/// </exception>
-		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, int length, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, int length, [NotNullWhen (true)] out Header? header)
+#else
+		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, int length, out Header? header)
+#endif
 		{
 			ParseUtils.ValidateArguments (options, buffer, startIndex, length);
 
@@ -1779,7 +1804,11 @@ namespace MimeKit {
 		/// <paramref name="startIndex"/> and <paramref name="length"/> do not specify
 		/// a valid range in the byte array.
 		/// </exception>
-		public static bool TryParse (byte[] buffer, int startIndex, int length, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		public static bool TryParse (byte[] buffer, int startIndex, int length, [NotNullWhen (true)] out Header? header)
+#else
+		public static bool TryParse (byte[] buffer, int startIndex, int length, out Header? header)
+#endif
 		{
 			return TryParse (ParserOptions.Default, buffer, startIndex, length, out header);
 		}
@@ -1803,7 +1832,11 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <paramref name="startIndex"/> is out of range.
 		/// </exception>
-		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, [NotNullWhen (true)] out Header? header)
+#else
+		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, out Header? header)
+#endif
 		{
 			ParseUtils.ValidateArguments (options, buffer, startIndex);
 
@@ -1832,7 +1865,11 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <paramref name="startIndex"/> is out of range.
 		/// </exception>
-		public static bool TryParse (byte[] buffer, int startIndex, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		public static bool TryParse (byte[] buffer, int startIndex, [NotNullWhen (true)] out Header? header)
+#else
+		public static bool TryParse (byte[] buffer, int startIndex, out Header? header)
+#endif
 		{
 			return TryParse (ParserOptions.Default, buffer, startIndex, out header);
 		}
@@ -1852,7 +1889,11 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="buffer"/> is <see langword="null"/>.</para>
 		/// </exception>
-		public static bool TryParse (ParserOptions options, byte[] buffer, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		public static bool TryParse (ParserOptions options, byte[] buffer, [NotNullWhen (true)] out Header? header)
+#else
+		public static bool TryParse (ParserOptions options, byte[] buffer, out Header? header)
+#endif
 		{
 			return TryParse (options, buffer, 0, out header);
 		}
@@ -1869,7 +1910,11 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentNullException">
 		/// <paramref name="buffer"/> is <see langword="null"/>.
 		/// </exception>
-		public static bool TryParse (byte[] buffer, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		public static bool TryParse (byte[] buffer, [NotNullWhen (true)] out Header? header)
+#else
+		public static bool TryParse (byte[] buffer, out Header? header)
+#endif
 		{
 			return TryParse (ParserOptions.Default, buffer, out header);
 		}
@@ -1889,7 +1934,11 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="text"/> is <see langword="null"/>.</para>
 		/// </exception>
-		public static bool TryParse (ParserOptions options, string text, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		public static bool TryParse (ParserOptions options, string text, [NotNullWhen(true)] out Header? header)
+#else
+		public static bool TryParse (ParserOptions options, string text, out Header? header)
+#endif
 		{
 			ParseUtils.ValidateArguments (options, text);
 
@@ -1914,7 +1963,11 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentNullException">
 		/// <paramref name="text"/> is <see langword="null"/>.
 		/// </exception>
-		public static bool TryParse (string text, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		public static bool TryParse (string text, [NotNullWhen(true)] out Header? header)
+#else
+		public static bool TryParse (string text, out Header? header)
+#endif
 		{
 			return TryParse (ParserOptions.Default, text, out header);
 		}

--- a/MimeKit/Header.cs
+++ b/MimeKit/Header.cs
@@ -26,18 +26,10 @@
 
 #nullable enable
 
-#if !NET5_0_OR_GREATER
-// MemberNotNull attribute is not available below net5.0
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-#endif
-
-
 using System;
 using System.Text;
 using System.Collections.Generic;
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Runtime.CompilerServices;
 
 using MimeKit.Utils;
@@ -1454,9 +1446,7 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="value"/> is <see langword="null"/>.</para>
 		/// </exception>
-#if NET5_0_OR_GREATER
-		[MemberNotNull(nameof(rawValue))]
-#endif
+		[MemberNotNull (nameof (rawValue))]
 		public void SetValue (FormatOptions format, Encoding encoding, string value)
 		{
 			if (format is null)
@@ -1497,9 +1487,7 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="value"/> is <see langword="null"/>.</para>
 		/// </exception>
-#if NET5_0_OR_GREATER
 		[MemberNotNull (nameof (rawValue))]
-#endif
 		public void SetValue (Encoding encoding, string value)
 		{
 			SetValue (FormatOptions.Default, encoding, value);
@@ -1672,11 +1660,7 @@ namespace MimeKit {
 			return c.IsBlank ();
 		}
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-		internal static unsafe bool TryParse (ParserOptions options, byte* input, int length, bool strict, [NotNullWhen(true)] out Header? header)
-#else
-		internal static unsafe bool TryParse (ParserOptions options, byte* input, int length, bool strict, out Header? header)
-#endif
+		internal static unsafe bool TryParse (ParserOptions options, byte* input, int length, bool strict, [NotNullWhen (true)] out Header? header)
 		{
 			byte* inend = input + length;
 			byte* start = input;
@@ -1770,11 +1754,7 @@ namespace MimeKit {
 		/// <paramref name="startIndex"/> and <paramref name="length"/> do not specify
 		/// a valid range in the byte array.
 		/// </exception>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, int length, [NotNullWhen (true)] out Header? header)
-#else
-		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, int length, out Header? header)
-#endif
 		{
 			ParseUtils.ValidateArguments (options, buffer, startIndex, length);
 
@@ -1804,11 +1784,7 @@ namespace MimeKit {
 		/// <paramref name="startIndex"/> and <paramref name="length"/> do not specify
 		/// a valid range in the byte array.
 		/// </exception>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 		public static bool TryParse (byte[] buffer, int startIndex, int length, [NotNullWhen (true)] out Header? header)
-#else
-		public static bool TryParse (byte[] buffer, int startIndex, int length, out Header? header)
-#endif
 		{
 			return TryParse (ParserOptions.Default, buffer, startIndex, length, out header);
 		}
@@ -1832,11 +1808,7 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <paramref name="startIndex"/> is out of range.
 		/// </exception>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, [NotNullWhen (true)] out Header? header)
-#else
-		public static bool TryParse (ParserOptions options, byte[] buffer, int startIndex, out Header? header)
-#endif
 		{
 			ParseUtils.ValidateArguments (options, buffer, startIndex);
 
@@ -1865,11 +1837,7 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <paramref name="startIndex"/> is out of range.
 		/// </exception>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 		public static bool TryParse (byte[] buffer, int startIndex, [NotNullWhen (true)] out Header? header)
-#else
-		public static bool TryParse (byte[] buffer, int startIndex, out Header? header)
-#endif
 		{
 			return TryParse (ParserOptions.Default, buffer, startIndex, out header);
 		}
@@ -1889,11 +1857,7 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="buffer"/> is <see langword="null"/>.</para>
 		/// </exception>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 		public static bool TryParse (ParserOptions options, byte[] buffer, [NotNullWhen (true)] out Header? header)
-#else
-		public static bool TryParse (ParserOptions options, byte[] buffer, out Header? header)
-#endif
 		{
 			return TryParse (options, buffer, 0, out header);
 		}
@@ -1910,11 +1874,7 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentNullException">
 		/// <paramref name="buffer"/> is <see langword="null"/>.
 		/// </exception>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 		public static bool TryParse (byte[] buffer, [NotNullWhen (true)] out Header? header)
-#else
-		public static bool TryParse (byte[] buffer, out Header? header)
-#endif
 		{
 			return TryParse (ParserOptions.Default, buffer, out header);
 		}
@@ -1934,11 +1894,7 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="text"/> is <see langword="null"/>.</para>
 		/// </exception>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-		public static bool TryParse (ParserOptions options, string text, [NotNullWhen(true)] out Header? header)
-#else
-		public static bool TryParse (ParserOptions options, string text, out Header? header)
-#endif
+		public static bool TryParse (ParserOptions options, string text, [NotNullWhen (true)] out Header? header)
 		{
 			ParseUtils.ValidateArguments (options, text);
 
@@ -1963,11 +1919,7 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentNullException">
 		/// <paramref name="text"/> is <see langword="null"/>.
 		/// </exception>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-		public static bool TryParse (string text, [NotNullWhen(true)] out Header? header)
-#else
-		public static bool TryParse (string text, out Header? header)
-#endif
+		public static bool TryParse (string text, [NotNullWhen (true)] out Header? header)
 		{
 			return TryParse (ParserOptions.Default, text, out header);
 		}

--- a/MimeKit/HeaderId.cs
+++ b/MimeKit/HeaderId.cs
@@ -24,6 +24,8 @@
 // THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 

--- a/MimeKit/HeaderList.cs
+++ b/MimeKit/HeaderList.cs
@@ -24,13 +24,18 @@
 // THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
+using System.Collections;
+using System.Collections.Generic;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Text;
 using System.Threading;
-using System.Collections;
 using System.Threading.Tasks;
-using System.Collections.Generic;
 
 using MimeKit.IO;
 using MimeKit.Utils;
@@ -594,7 +599,7 @@ namespace MimeKit {
 		/// <exception cref="System.ArgumentNullException">
 		/// <paramref name="value"/> is <see langword="null"/>.
 		/// </exception>
-		public string this [HeaderId id] {
+		public string? this [HeaderId id] {
 			get {
 				if (id == HeaderId.Unknown)
 					throw new ArgumentOutOfRangeException (nameof (id));
@@ -634,7 +639,7 @@ namespace MimeKit {
 		/// <para>-or-</para>
 		/// <para><paramref name="value"/> is <see langword="null"/>.</para>
 		/// </exception>
-		public string this [string field] {
+		public string? this [string field] {
 			get {
 				if (field is null)
 					throw new ArgumentNullException (nameof (field));
@@ -1205,24 +1210,32 @@ namespace MimeKit {
 
 		#endregion
 
-		internal event EventHandler<HeaderListChangedEventArgs> Changed;
+		internal event EventHandler<HeaderListChangedEventArgs>? Changed;
 
-		void HeaderChanged (object sender, EventArgs args)
+		void HeaderChanged (object? sender, EventArgs args)
 		{
-			OnChanged ((Header) sender, HeaderListChangedAction.Changed);
+			OnChanged (sender as Header, HeaderListChangedAction.Changed);
 		}
 
-		void OnChanged (Header header, HeaderListChangedAction action)
+		void OnChanged (Header? header, HeaderListChangedAction action)
 		{
 			Changed?.Invoke (this, new HeaderListChangedEventArgs (header, action));
 		}
 
-		internal bool TryGetHeader (HeaderId id, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		internal bool TryGetHeader (HeaderId id, [NotNullWhen(true)] out Header? header)
+#else
+		internal bool TryGetHeader (HeaderId id, out Header? header)
+#endif
 		{
 			return table.TryGetValue (id.ToHeaderName (), out header);
 		}
 
-		internal bool TryGetHeader (string field, out Header header)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+		internal bool TryGetHeader (string field, [NotNullWhen (true)] out Header? header)
+#else
+		internal bool TryGetHeader (string field, out Header? header)
+#endif
 		{
 			return table.TryGetValue (field, out header);
 		}

--- a/MimeKit/HeaderList.cs
+++ b/MimeKit/HeaderList.cs
@@ -27,15 +27,13 @@
 #nullable enable
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-using System.Diagnostics.CodeAnalysis;
-#endif
 using System.IO;
 using System.Text;
 using System.Threading;
+using System.Collections;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using MimeKit.IO;
 using MimeKit.Utils;
@@ -1222,20 +1220,12 @@ namespace MimeKit {
 			Changed?.Invoke (this, new HeaderListChangedEventArgs (header, action));
 		}
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-		internal bool TryGetHeader (HeaderId id, [NotNullWhen(true)] out Header? header)
-#else
-		internal bool TryGetHeader (HeaderId id, out Header? header)
-#endif
+		internal bool TryGetHeader (HeaderId id, [NotNullWhen (true)] out Header? header)
 		{
 			return table.TryGetValue (id.ToHeaderName (), out header);
 		}
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 		internal bool TryGetHeader (string field, [NotNullWhen (true)] out Header? header)
-#else
-		internal bool TryGetHeader (string field, out Header? header)
-#endif
 		{
 			return table.TryGetValue (field, out header);
 		}

--- a/MimeKit/HeaderListChangedEventArgs.cs
+++ b/MimeKit/HeaderListChangedEventArgs.cs
@@ -24,6 +24,8 @@
 // THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 
 namespace MimeKit {
@@ -57,7 +59,7 @@ namespace MimeKit {
 
 	class HeaderListChangedEventArgs : EventArgs
 	{
-		internal HeaderListChangedEventArgs (Header header, HeaderListChangedAction action)
+		internal HeaderListChangedEventArgs (Header? header, HeaderListChangedAction action)
 		{
 			Header = header;
 			Action = action;
@@ -67,7 +69,7 @@ namespace MimeKit {
 			get; private set;
 		}
 
-		public Header Header {
+		public Header? Header {
 			get; private set;
 		}
 	}

--- a/MimeKit/HeaderListCollection.cs
+++ b/MimeKit/HeaderListCollection.cs
@@ -24,6 +24,8 @@
 // THE SOFTWARE.
 //
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -236,14 +238,14 @@ namespace MimeKit {
 			return GetEnumerator ();
 		}
 
-		internal event EventHandler Changed;
+		internal event EventHandler? Changed;
 
 		void OnChanged ()
 		{
 			Changed?.Invoke (this, EventArgs.Empty);
 		}
 
-		void OnGroupChanged (object sender, HeaderListChangedEventArgs e)
+		void OnGroupChanged (object? sender, HeaderListChangedEventArgs e)
 		{
 			OnChanged ();
 		}


### PR DESCRIPTION
This pull request enables nullable reference types for (addresses #1067):
- `Header`
- `HeaderId`
- `HeaderList`
- `HeaderListChangedEventArgs`
- `HeaderListCollection`