### PR TITLE
docs: remove .NET forum discussion link as it does not exist anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1245,5 +1245,3 @@ A copy of the XML-formatted API reference documentation is also included in the 
 MimeKit is a [.NET Foundation](https://www.dotnetfoundation.org/projects) project.
 
 This project has adopted the code of conduct defined by the [Contributor Covenant](https://contributor-covenant.org/) to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](https://www.dotnetfoundation.org/code-of-conduct).
-
-General .NET OSS discussions: [.NET Foundation forums](https://forums.dotnetfoundation.org)


### PR DESCRIPTION
I found no replacement. https://dotnetfoundation.org/community/ may be the best equivalent, but even there no real community forum can be found anymore?

Maybe they now use Discord or what? But that is not the same, IMHO. And not worth promoting in any case.