### PR TITLE
Update HeaderId to clarify the difference between Autosubmitted and Auto-Submitted

### DIFF
--- a/MimeKit/HeaderId.cs
+++ b/MimeKit/HeaderId.cs
@@ -122,7 +122,7 @@ namespace MimeKit {
 		/// The Auto-Submitted header field.
 		/// </summary>
 		/// <remarks>
-		/// The header as defined in <see href="https://www.rfc-editor.org/rfc/rfc3834">RFC3834</see>
+		/// The header as defined in <see href="https://www.rfc-editor.org/rfc/rfc3834">RFC3834</see>.
 		/// </remarks>
 		AutoSubmitted,
 

--- a/MimeKit/HeaderId.cs
+++ b/MimeKit/HeaderId.cs
@@ -130,8 +130,10 @@ namespace MimeKit {
 		/// The Autosubmitted header field.
 		/// </summary>
 		/// <remarks>
-		/// <b>Important:</b> This is more a legacy header as defined in <see href="https://datatracker.ietf.org/doc/html/rfc2156"/>RFC2156</see>. <br>
-		/// Usually, you likely want to use <see cref="AutoSubmitted"/> instead.
+		/// <note type="warning">
+		/// <para>This is a legacy header as defined in <see href="https://datatracker.ietf.org/doc/html/rfc2156"/>RFC2156</see>.</para>
+		/// <para>Most likely, you want to use <see cref="AutoSubmitted"/> instead.</para>
+		/// </note>
 		/// </remarks>
 		Autosubmitted,
 

--- a/MimeKit/HeaderId.cs
+++ b/MimeKit/HeaderId.cs
@@ -121,11 +121,18 @@ namespace MimeKit {
 		/// <summary>
 		/// The Auto-Submitted header field.
 		/// </summary>
+		/// <remarks>
+		/// The header as defined in <see href="https://www.rfc-editor.org/rfc/rfc3834">RFC3834</see>
+		/// </remarks>
 		AutoSubmitted,
 
 		/// <summary>
 		/// The Autosubmitted header field.
 		/// </summary>
+		/// <remarks>
+		/// <b>Important:</b> This is more a legacy header as defined in <see href="https://datatracker.ietf.org/doc/html/rfc2156"/>RFC2156</see>. <br>
+		/// Usually, you likely want to use <see cref="AutoSubmitted"/> instead.
+		/// </remarks>
 		Autosubmitted,
 
 		/// <summary>


### PR DESCRIPTION
This was totally confusing for me why there are two header IDs in MimeKit with the quite very same header. I even suspected a bug or that it is just a legacy API-compatibility thing (one being deprecated, though not stated?).

After some research it turns out, the header is actually defined. At least for the modern RFC3834 header the keywords are actually also defined by IANA: https://www.iana.org/assignments/auto-submitted-keywords/auto-submitted-keywords.xml (But you don't do mapping to an enum, so introducing this would change the API drastically and be a different/bigger task, so I thought for the code this may not be relevant.)

So to clarify this and ease searching around the web and decrease potential confusion for other developers, IMHO, it is a good idea to just directly point out the basic difference in the (code) doc, directly where you are using it.

For background, I am at https://github.com/jstedfast/MimeKit/issues/938#issuecomment-2388847922 here detecting auto-reply mails for which this header is very important.