### PR TITLE
Reduce dependencies for NetStandard2.1

### DIFF
--- a/MimeKit/MimeKit.csproj
+++ b/MimeKit/MimeKit.csproj
@@ -71,13 +71,12 @@
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
-	
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2.')) ">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) Or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Buffers" Version="4.6.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />

--- a/MimeKit/MimeKitLite.csproj
+++ b/MimeKit/MimeKitLite.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>An Open Source library for creating and parsing MIME, S/MIME, PGP messages on desktop and mobile platforms.</Description>
@@ -57,17 +57,13 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2.')) ">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) ">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) Or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Buffers" Version="4.6.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nuget/MimeKit.nuspec
+++ b/nuget/MimeKit.nuspec
@@ -92,12 +92,9 @@
         <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
       <group targetFramework="netstandard2.1">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
         <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" />
         <dependency id="System.Formats.Asn1" version="8.0.1" />
         <dependency id="System.Text.Encoding.CodePages" version="8.0.0" />
-        <dependency id="System.Buffers" version="4.6.0" />
-        <dependency id="System.Memory" version="4.5.5" />
         <dependency id="BouncyCastle.Cryptography" version="2.4.0" />
       </group>
     </dependencies>

--- a/nuget/MimeKitLite.nuspec
+++ b/nuget/MimeKitLite.nuspec
@@ -63,17 +63,12 @@
       <group targetFramework="net8.0" />
       <group targetFramework="netstandard2.0">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
-        <dependency id="System.Reflection.TypeExtensions" version="4.7.0" />
         <dependency id="System.Text.Encoding.CodePages" version="8.0.0" />
         <dependency id="System.Buffers" version="4.6.0" />
         <dependency id="System.Memory" version="4.5.5" />
       </group>
       <group targetFramework="netstandard2.1">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
-        <dependency id="System.Reflection.TypeExtensions" version="4.7.0" />
         <dependency id="System.Text.Encoding.CodePages" version="8.0.0" />
-        <dependency id="System.Buffers" version="4.6.0" />
-        <dependency id="System.Memory" version="4.5.5" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
NetStandard2.1 implicitly supports Span, so can exclude these explicit dependencies:
```
    <PackageReference Include="System.Buffers" Version="4.5.1" />
    <PackageReference Include="System.Memory" Version="4.5.5" />
```
This dependency is also no longer needed for MimeKit:
```
    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
```