### PR TITLE
Allow easier implementation of IX509CertificateDatabase and BouncyCastleSecureMimeContext

### DIFF
--- a/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
+++ b/MimeKit/Cryptography/BouncyCastleCertificateExtensions.cs
@@ -67,7 +67,15 @@ namespace MimeKit.Cryptography {
 			return new X509Certificate2 (certificate.GetEncoded ());
 		}
 
-		internal static bool IsSelfSigned (this X509Certificate certificate)
+		/// <summary>
+		/// Determines whether the specified certificate is self-signed.
+		/// </summary>
+		/// <remarks>
+		/// A certificate is considered self-signed if the subject and issuer names are the same.
+		/// </remarks>
+		/// <param name="certificate">The certificate to check.</param>
+		/// <returns><c>true</c> if the certificate is self-signed; otherwise, <c>false</c>.</returns>
+		public static bool IsSelfSigned (this X509Certificate certificate)
 		{
 			return certificate.SubjectDN.Equivalent (certificate.IssuerDN);
 		}
@@ -259,7 +267,20 @@ namespace MimeKit.Cryptography {
 			return PublicKeyAlgorithm.None;
 		}
 
-		internal static X509KeyUsageFlags GetKeyUsageFlags (bool[] usage)
+		/// <summary>
+		/// Generates an X509KeyUsageFlags value based on the provided usage bit array.
+		/// </summary>
+		/// <param name="usage">A boolean array representing the key usage bits.
+		/// Each index corresponds to a specific value defined  by <see cref="X509KeyUsageBits"/>
+		/// </param>
+		/// <returns>
+		/// An X509KeyUsageFlags value that represents the combined key usage flags.
+		/// </returns>
+		/// <remarks>
+		/// If the usage array is null, all key usage flags are considered enabled by
+		/// returning a <see cref="X509KeyUsageFlags.None"/>
+		/// </remarks>
+		public static X509KeyUsageFlags GetKeyUsageFlags (bool[] usage)
 		{
 			var flags = X509KeyUsageFlags.None;
 
@@ -353,7 +374,17 @@ namespace MimeKit.Cryptography {
 			return new EncryptionAlgorithm[] { EncryptionAlgorithm.TripleDes };
 		}
 
-		internal static bool IsDelta (this X509Crl crl)
+		/// <summary>
+		/// Determines whether the specified X.509 CRL is a delta CRL.
+		/// </summary>
+		/// <remarks>
+		/// A delta CRL contains updates to a previously issued CRL. This method checks
+		/// if the CRL contains the Delta CRL Indicator extension.
+		/// <note>The X.509 delta CRL indicator extension must be marked critical to be found.</note>
+		/// </remarks>
+		/// <param name="crl">The X.509 CRL to check.</param>
+		/// <returns><c>true</c> if the specified CRL is a delta CRL; otherwise, <c>false</c>.</returns>
+		public static bool IsDelta (this X509Crl crl)
 		{
 			var critical = crl.GetCriticalExtensionOids ();
 

--- a/MimeKit/Cryptography/X509KeyUsageFlags.cs
+++ b/MimeKit/Cryptography/X509KeyUsageFlags.cs
@@ -107,15 +107,61 @@ namespace MimeKit.Cryptography {
 		DecipherOnly     = 1 << 15
 	}
 
-	enum X509KeyUsageBits {
+	/// <summary>
+	/// X.509 key usage bits.
+	/// </summary>
+	/// <remarks>
+	/// <para>The X.509 Key Usage Bits can be used to determine what operations
+	/// a certificate can be used for which is similar to <see cref="X509KeyUsageFlags"/> but
+	/// the usage of this is enum represents a position in a bit array.</para> 
+	/// </remarks>
+	public enum X509KeyUsageBits
+	{
+		/// <summary>
+		/// The key may be used for digitally signing data.
+		/// </summary>
 		DigitalSignature,
+
+		/// <summary>
+		/// The key may be used to verify digital signatures used to
+		/// provide a non-repudiation service.
+		/// </summary>
 		NonRepudiation,
+
+		/// <summary>
+		/// The key is meant to be used for key encipherment.
+		/// </summary>
 		KeyEncipherment,
+
+		/// <summary>
+		/// The key may be used for data encipherment.
+		/// </summary>
 		DataEncipherment,
+
+		/// <summary>
+		/// The key is meant to be used for key agreement.
+		/// </summary>
 		KeyAgreement,
+
+		/// <summary>
+		/// The key may be used for verifying signatures on certificates.
+		/// </summary>
 		KeyCertSign,
+
+		/// <summary>
+		/// The key may be used for verifying signatures on
+		/// certificate revocation lists (CRLs).
+		/// </summary>
 		CrlSign,
+
+		/// <summary>
+		/// The key may only be used for enciphering data during key agreement.
+		/// </summary>
 		EncipherOnly,
+
+		/// <summary>
+		/// The key may only be used for deciphering data during key agreement.
+		/// </summary>
 		DecipherOnly,
 	}
 }


### PR DESCRIPTION
While implementing IX509CertificateDatabase and extending BouncyCastleSecureMimeContext I ran into a few internal methods I would like to use for consistency. This PR exposes those with code documentation.

I chose this crypto-abstratctions branch because I thought it might be the appropriate place but I could change the PR to the main branch if my changes are acceptable.

I have more PRs. I just want to ensure they are something you are OK with.

Future PR themes I have ready are:

Ability to find end certificate in IX509CertificateDatabase for signing and encryptiing with techniques other than Email. I work on a OS project called the [nhin-d](https://github.com/DirectProject/nhin-d) refered to as the Direct Project. It is a SMIME protocol where the public certificates are disoverable in DNS via CERT records. We search by email first replacing the @ symbol with a dot and if not found then we search by domain name. The domain name is the friction I have with todays implementation when trying to find the private key for signing. My first stab at this was to import the certificate into the X509CertificateRecord and use Subject Alt Names of DNS type as a fall back in the GetSubjectEmailAddress extension. Semantically it is not the SubjectEmail but it works when I search.
Ability to terminate trust as a trust anchor rather than the CA. This is common in the Direct Project and expect it would be in standard SMIME as well. This does involve a way to express that a certificate should be the anchor other than being self signed.
Intermediate and CRLs downloaded on demand and cached. There was one place where the CRL is downloaded but I added that and the intermediate along with their CRLs also. I do need to put more work into it so it can chase the missing intermediates with many in the chain.
maybe add a wrapping feature where we can wrap a message before signing and encrypting using a specific list of headers we want to expose and content-type=message/rfc822. Yes that is specified in the Direct Project as well. Should be comming from rfc 3851. Maybe the code has the mechanics for this already and I just haven't noticed it.
I have a test harness localy where I have ensured I could wrap, sign and encrypt witht he Direct Project reference implementation and the Decrypt with MimeKit and the reverse. In my more modern offline version we use MimeKit heavily for but there is a lot of tranlation between MimeKit and our Direct Project implementation of Mime. This experiment shows me that we could adopt MimeKit as our SMIME api and save a lot in allocations.

Thanks for reading this far and of course thanks for one of the best c# OS contributions.

-- Joe