### PR TITLE
Fix up dsa.ImportParameters method for Ubuntu runs

### DIFF
--- a/MimeKit/Cryptography/AsymmetricAlgorithmExtensions.cs
+++ b/MimeKit/Cryptography/AsymmetricAlgorithmExtensions.cs
@@ -247,8 +247,13 @@ namespace MimeKit.Cryptography {
 			var parameters = GetDSAParameters (key);
 			parameters.X = GetPaddedByteArray (key.X, parameters.Q.Length);
 
-			if (pub != null)
+			if (pub != null) {
 				parameters.Y = GetPaddedByteArray (pub.Y, parameters.P.Length);
+
+			} else {
+				// If pub is null, derive Y from the private key parameters
+				parameters.Y = key.Parameters.G.ModPow (key.X, key.Parameters.P).ToByteArrayUnsigned ();
+			}
 
 			var dsa = new DSACryptoServiceProvider ();
 


### PR DESCRIPTION
Everything below was from my original comments when I first solved this failing test.  Originally I thought the test was a new failure.  But then realized that it has been around for a while but not being surfaced as a failed check.  I thought it was related to something I did or OS updates.  Anyway I figured it out.


> It seems to be something about some updates in the OS.  Maybe OpenSSL changes or OS changes.  It broke on the Build server and locally on my Ubuntu 22.04 that I recently updated.
> 
> After hours of debugging and finally getting the debugger to attach to the test I could narrow down where the error was happening.  Copilot helped me to find a solution.  I included the explanation here:
> 
> Certainly! The line parameters.Y = key.Parameters.G.ModPow(key.X, key.Parameters.P).ToByteArrayUnsigned(); is used to derive the public key component Y from the private key components in the DSA (Digital Signature Algorithm) parameters. Here's a detailed explanation: DSA Key Components
> •	P: A large prime number.
> •	Q: A prime divisor of P-1.
> •	G: A generator of a subgroup of order Q in the multiplicative group of integers modulo P. •	X: The private key, which is a randomly chosen integer such that 0 < X < Q. •	Y: The public key, which is derived from the private key. Deriving the Public Key Y
> In DSA, the public key Y is derived from the private key X using the following formula: [ Y = G^X \mod P ] Where: •	G is the generator.
> •	X is the private key.
> •	P is the prime modulus.
> Explanation of the Code
> •	key.Parameters.G: This is the generator G.
> •	key.X: This is the private key X.
> •	key.Parameters.P: This is the prime modulus P.
> The method ModPow is used to perform modular exponentiation, which calculates ( G^X \mod P ). This operation is efficient and secure for large numbers, which are typical in cryptographic algorithms. •	key.Parameters.G.ModPow(key.X, key.Parameters.P): This calculates ( G^X \mod P ), resulting in the public key Y as a BigInteger. •	.ToByteArrayUnsigned(): This converts the resulting BigInteger to an unsigned byte array, which is the format required by the DSAParameters structure.