### PR TITLE
Update HtmlPreviewVisitor to handle text/calender scheduling events

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -252,6 +252,10 @@ For example, you may wish to treat all body parts having a `name` or `filename` 
 var attachments = message.BodyParts.OfType<MimePart> ().Where (part => !string.IsNullOrEmpty (part.FileName));
 ```
 
+Some message contain calendaring and scheduling information. The `Content-Type` is `text/calender`, see [Wikipedia iCalender](https://en.wikipedia.org/wiki/ICalendar) or [IETF RFC5545](https://datatracker.ietf.org/doc/html/rfc5545).
+To get the list of body parts matching this criteria, you can use the
+[MimeMessage.CalenderAttachments](https://www.mimekit.net/docs/html/P_MimeKit_MimeMessage_CalenderAttachments.htm) property. One may provide this as `*.ics` file.
+
 A more sophisticated approach is to treat body parts not referenced by the main textual body part of the
 message as attachments. In other words, treat any body part not used for rendering the message as an
 attachment. For an example on how to do this, consider the following code snippets:
@@ -264,6 +268,8 @@ class HtmlPreviewVisitor : MimeVisitor
 {
     List<MultipartRelated> stack = new List<MultipartRelated> ();
     List<MimeEntity> attachments = new List<MimeEntity> ();
+    List<MimeEntity> calenderAttachments = new List<MimeEntity>();
+
     readonly string tempDir;
     string body;
 
@@ -281,6 +287,14 @@ class HtmlPreviewVisitor : MimeVisitor
     /// </summary>
     public IList<MimeEntity> Attachments {
         get { return attachments; }
+    }
+
+    /// <summary>
+    /// The list of text/calender entries that were in the MimeMessage.
+    /// </summary>
+    public IList<MimeEntity> CalenderAttachments
+    {
+        get { return calenderAttachments; }
     }
 
     /// <summary>
@@ -464,6 +478,14 @@ class HtmlPreviewVisitor : MimeVisitor
             attachments.Add (entity);
             return;
         }
+
+        // we want to treat text/calendar as an attachment, not as a regular text part.
+        if (entity.ContentType.IsMimeType("text", "calendar"))
+        {
+            calenderAttachments.Add (entity);
+            return;
+        }
+
 
         if (entity.IsHtml) {
             converter = new HtmlToHtml {

--- a/samples/MessageReader.Android/MessageReader.Android/HtmlPreviewVisitor.cs
+++ b/samples/MessageReader.Android/MessageReader.Android/HtmlPreviewVisitor.cs
@@ -42,6 +42,8 @@ namespace MessageReader.Android
 	{
 		readonly List<MultipartRelated> stack = new List<MultipartRelated> ();
 		readonly List<MimeEntity> attachments = new List<MimeEntity> ();
+		readonly List<MimeEntity> calenderAttachments = new List<MimeEntity>();
+
 		readonly WebView webView;
 		bool renderedBody;
 
@@ -58,6 +60,14 @@ namespace MessageReader.Android
 		/// </summary>
 		public IList<MimeEntity> Attachments {
 			get { return attachments; }
+		}
+
+		/// <summary>
+		/// The list of text/calender entries that were in the MimeMessage.
+		/// </summary>
+		public IList<MimeEntity> CalenderAttachments
+		{
+			get { return calenderAttachments; }
 		}
 
 		protected override void VisitMultipartAlternative (MultipartAlternative alternative)
@@ -130,6 +140,13 @@ namespace MessageReader.Android
 			if (renderedBody) {
 				// since we've already found the body, treat this as an attachment
 				attachments.Add (entity);
+				return;
+			}
+
+			// we want to treat text/calendar as an attachment, not as a regular text part.
+			if (entity.ContentType.IsMimeType ("text", "calendar"))
+			{
+				calenderAttachments.Add (entity);
 				return;
 			}
 

--- a/samples/MessageReader.iOS/MessageReader.iOS/HtmlPreviewVisitor.cs
+++ b/samples/MessageReader.iOS/MessageReader.iOS/HtmlPreviewVisitor.cs
@@ -42,6 +42,8 @@ namespace MessageReader.iOS {
 	{
 		readonly List<MultipartRelated> stack = new List<MultipartRelated> ();
 		readonly List<MimeEntity> attachments = new List<MimeEntity> ();
+		readonly List<MimeEntity> calenderAttachments = new List<MimeEntity>();
+
 		readonly UIWebView webView;
 		bool renderedBody;
 
@@ -58,6 +60,14 @@ namespace MessageReader.iOS {
 		/// </summary>
 		public IList<MimeEntity> Attachments {
 			get { return attachments; }
+		}
+
+		/// <summary>
+		/// The list of text/calender entries that were in the MimeMessage.
+		/// </summary>
+		public IList<MimeEntity> CalenderAttachments
+		{
+			get { return calenderAttachments; }
 		}
 
 		protected override void VisitMultipartAlternative (MultipartAlternative alternative)
@@ -130,6 +140,13 @@ namespace MessageReader.iOS {
 			if (renderedBody) {
 				// since we've already found the body, treat this as an attachment
 				attachments.Add (entity);
+				return;
+			}
+
+			// we want to treat text/calendar as an attachment, not as a regular text part.
+			if (entity.ContentType.IsMimeType ("text", "calendar"))
+			{
+				calenderAttachments.Add (entity);
 				return;
 			}
 

--- a/samples/MessageReader/MessageReader/HtmlPreviewVisitor.cs
+++ b/samples/MessageReader/MessageReader/HtmlPreviewVisitor.cs
@@ -41,6 +41,8 @@ namespace MessageReader
 	{
 		readonly List<MultipartRelated> stack = new List<MultipartRelated> ();
 		readonly List<MimeEntity> attachments = new List<MimeEntity> ();
+		readonly List<MimeEntity> calenderAttachments = new List<MimeEntity>();
+
 		string body;
 
 		/// <summary>
@@ -55,6 +57,14 @@ namespace MessageReader
 		/// </summary>
 		public IList<MimeEntity> Attachments {
 			get { return attachments; }
+		}
+
+		/// <summary>
+		/// The list of text/calender entries that were in the MimeMessage.
+		/// </summary>
+		public IList<MimeEntity> CalenderAttachments
+		{
+			get { return calenderAttachments; }
 		}
 
 		/// <summary>
@@ -209,6 +219,13 @@ namespace MessageReader
 			if (body != null) {
 				// since we've already found the body, treat this as an attachment
 				attachments.Add (entity);
+				return;
+			}
+
+			// we want to treat text/calendar as an attachment, not as a regular text part.
+			if (entity.ContentType.IsMimeType ("text", "calendar"))
+			{
+				calenderAttachments.Add (entity);
 				return;
 			}
 


### PR DESCRIPTION
This PR is related to  this https://github.com/jstedfast/MimeKit/discussions/1118 Discussion.

Some message contain text/calender content. Currently this is handled as default text content so the original text will be replaced by the content of the calender content.

To avoid this we check inside `VisitTextPart` if the content-type is calender and if so we handle it as a specific kind of attachment.



