### PR TITLE
Fix There is already an open DataReader. Fix command needs to have a …

### DIFF
--- a/MimeKit/Cryptography/SQLServerCertificateDatabase.cs
+++ b/MimeKit/Cryptography/SQLServerCertificateDatabase.cs
@@ -99,10 +99,10 @@ namespace MimeKit.Cryptography {
 			int primaryKeys = table.PrimaryKey?.Length ?? 0;
 
 			statement.Append (table.TableName);
-			statement.Append (" ADD COLUMN ");
+			statement.Append (" ADD ");
 			Build (statement, table, column, ref primaryKeys);
 
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand (connection)) {
 				command.CommandText = statement.ToString ();
 				command.CommandType = CommandType.Text;
 				command.ExecuteNonQuery ();
@@ -134,7 +134,7 @@ namespace MimeKit.Cryptography {
 
 			statement.Append (')');
 
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand (connection)) {
 				command.CommandText = statement.ToString ();
 				command.CommandType = CommandType.Text;
 				command.ExecuteNonQuery ();
@@ -188,7 +188,7 @@ namespace MimeKit.Cryptography {
 		/// <returns>The list of columns.</returns>
 		protected override IList<DataColumn> GetTableColumns (DbConnection connection, string tableName)
 		{
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand (connection)) {
 				command.CommandText = $"select top 1 * from {tableName}";
 				using (var reader = command.ExecuteReader ()) {
 					var columns = new List<DataColumn> ();
@@ -216,7 +216,7 @@ namespace MimeKit.Cryptography {
 			var indexName = GetIndexName (tableName, columnNames);
 			var query = string.Format ("IF NOT EXISTS (Select 8 from sys.indexes where name='{0}' and object_id=OBJECT_ID('{1}')) CREATE INDEX {0} ON {1}({2})", indexName, tableName, string.Join (", ", columnNames));
 
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand (connection)) {
 				command.CommandText = query;
 				command.ExecuteNonQuery ();
 			}
@@ -236,7 +236,7 @@ namespace MimeKit.Cryptography {
 			var indexName = GetIndexName (tableName, columnNames);
 			var query = string.Format ("IF EXISTS (Select 8 from sys.indexes where name='{0}' and object_id=OBJECT_ID('{1}')) DROP INDEX {0} ON {1}", indexName, tableName);
 
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand (connection)) {
 				command.CommandText = query;
 				command.ExecuteNonQuery ();
 			}
@@ -257,7 +257,7 @@ namespace MimeKit.Cryptography {
 			var fingerprint = certificate.GetFingerprint ().ToLowerInvariant ();
 			var serialNumber = certificate.SerialNumber.ToString ();
 			var issuerName = certificate.IssuerDN.ToString ();
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand (connection);
 			var query = CreateSelectQuery (fields).Replace ("SELECT", "SELECT top 1");
 
 			// FIXME: Is this really the best way to query for an exact match of a certificate?
@@ -285,7 +285,7 @@ namespace MimeKit.Cryptography {
 		{
 			var statement = new StringBuilder ("INSERT INTO CERTIFICATES(");
 			var variables = new StringBuilder ("VALUES(");
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 			var columns = CertificatesTable.Columns;
 
 			for (int i = 1; i < columns.Count; i++) {

--- a/MimeKit/Cryptography/SqlCertificateDatabase.cs
+++ b/MimeKit/Cryptography/SqlCertificateDatabase.cs
@@ -42,6 +42,7 @@ using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.X509.Store;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities.Collections;
+using System.Linq;
 
 namespace MimeKit.Cryptography {
 	/// <summary>
@@ -56,7 +57,7 @@ namespace MimeKit.Cryptography {
 	public abstract class SqlCertificateDatabase : X509CertificateDatabase
 	{
 		bool disposed;
-
+		DbTransaction activeTransaction;
 		/// <summary>
 		/// Initialize a new instance of the <see cref="SqlCertificateDatabase"/> class.
 		/// </summary>
@@ -224,7 +225,7 @@ namespace MimeKit.Cryptography {
 			var indexName = GetIndexName (tableName, columnNames);
 			var query = string.Format ("CREATE INDEX IF NOT EXISTS {0} ON {1}({2})", indexName, tableName, string.Join (", ", columnNames));
 
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand (connection)) {
 				command.CommandText = query;
 				command.ExecuteNonQuery ();
 			}
@@ -244,7 +245,7 @@ namespace MimeKit.Cryptography {
 			var indexName = GetIndexName (tableName, columnNames);
 			var query = string.Format ("DROP INDEX IF EXISTS {0}", indexName);
 
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand(connection)) {
 				command.CommandText = query;
 				command.ExecuteNonQuery ();
 			}
@@ -274,44 +275,38 @@ namespace MimeKit.Cryptography {
 
 			if (!hasAnchorColumn) {
 				// Upgrade from Version 1.
-				using (var transaction = connection.BeginTransaction ()) {
-					try {
-						var column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.Anchor)];
-						AddTableColumn (connection, table, column);
+				ExecuteWithinTransaction (connection, () => {
 
-						column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.SubjectName)];
-						AddTableColumn (connection, table, column);
+					var column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.Anchor)];
+					AddTableColumn (connection, table, column);
 
-						column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.SubjectKeyIdentifier)];
-						AddTableColumn (connection, table, column);
+					column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.SubjectName)];
+					AddTableColumn (connection, table, column);
 
-						// Note: The SubjectEmail column exists, but the SubjectDnsNames column was added later, so make sure to add that.
-						column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.SubjectDnsNames)];
-						AddTableColumn (connection, table, column);
+					column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.SubjectKeyIdentifier)];
+					AddTableColumn (connection, table, column);
 
-						foreach (var record in Find (null, false, X509CertificateRecordFields.Id | X509CertificateRecordFields.Certificate)) {
-							var statement = $"UPDATE {CertificatesTableName} SET {CertificateColumnNames.Anchor} = @ANCHOR, {CertificateColumnNames.SubjectName} = @SUBJECTNAME, {CertificateColumnNames.SubjectKeyIdentifier} = @SUBJECTKEYIDENTIFIER, {CertificateColumnNames.SubjectEmail} = @SUBJECTEMAIL, {CertificateColumnNames.SubjectDnsNames} = @SUBJECTDNSNAMES WHERE {CertificateColumnNames.Id} = @ID";
+					// Note: The SubjectEmail column exists, but the SubjectDnsNames column was added later, so make sure to add that.
+					column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.SubjectDnsNames)];
+					AddTableColumn (connection, table, column);
 
-							using (var command = connection.CreateCommand ()) {
-								command.AddParameterWithValue ("@ID", record.Id);
-								command.AddParameterWithValue ("@ANCHOR", record.IsAnchor);
-								command.AddParameterWithValue ("@SUBJECTNAME", record.SubjectName);
-								command.AddParameterWithValue ("@SUBJECTKEYIDENTIFIER", record.SubjectKeyIdentifier?.AsHex ());
-								command.AddParameterWithValue ("@SUBJECTEMAIL", record.SubjectEmail);
-								command.AddParameterWithValue ("@SUBJECTDNSNAMES", EncodeDnsNames (record.SubjectDnsNames));
-								command.CommandType = CommandType.Text;
-								command.CommandText = statement;
+					foreach (var record in Find (null, false, X509CertificateRecordFields.Id | X509CertificateRecordFields.Certificate).ToArray ()) {
+						var statement = $"UPDATE {CertificatesTableName} SET {CertificateColumnNames.Anchor} = @ANCHOR, {CertificateColumnNames.SubjectName} = @SUBJECTNAME, {CertificateColumnNames.SubjectKeyIdentifier} = @SUBJECTKEYIDENTIFIER, {CertificateColumnNames.SubjectEmail} = @SUBJECTEMAIL, {CertificateColumnNames.SubjectDnsNames} = @SUBJECTDNSNAMES WHERE {CertificateColumnNames.Id} = @ID";
 
-								command.ExecuteNonQuery ();
-							}
+						using (var command = CreateDbCommand (connection)) {
+							command.AddParameterWithValue ("@ID", record.Id);
+							command.AddParameterWithValue ("@ANCHOR", record.IsAnchor);
+							command.AddParameterWithValue ("@SUBJECTNAME", record.SubjectName);
+							command.AddParameterWithValue ("@SUBJECTKEYIDENTIFIER", record.SubjectKeyIdentifier?.AsHex ());
+							command.AddParameterWithValue ("@SUBJECTEMAIL", record.SubjectEmail);
+							command.AddParameterWithValue ("@SUBJECTDNSNAMES", EncodeDnsNames (record.SubjectDnsNames));
+							command.CommandType = CommandType.Text;
+							command.CommandText = statement;
+
+							command.ExecuteNonQuery ();
 						}
-
-						transaction.Commit ();
-					} catch {
-						transaction.Rollback ();
-						throw;
 					}
-				}
+				});
 
 				// Remove some old indexes
 				RemoveIndex (connection, table.TableName, CertificateColumnNames.Trusted);
@@ -321,31 +316,24 @@ namespace MimeKit.Cryptography {
 				RemoveIndex (connection, table.TableName, CertificateColumnNames.BasicConstraints, CertificateColumnNames.SubjectEmail);
 			} else if (!hasSubjectDnsNamesColumn) {
 				// Upgrade from Version 2.
-				using (var transaction = connection.BeginTransaction ()) {
-					try {
-						var column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.SubjectDnsNames)];
-						AddTableColumn (connection, table, column);
+				ExecuteWithinTransaction (connection, () => {
+					var column = table.Columns[table.Columns.IndexOf (CertificateColumnNames.SubjectDnsNames)];
+					AddTableColumn (connection, table, column);
 
-						foreach (var record in Find (null, false, X509CertificateRecordFields.Id | X509CertificateRecordFields.Certificate)) {
-							var statement = $"UPDATE {CertificatesTableName} SET {CertificateColumnNames.SubjectEmail} = @SUBJECTEMAIL, {CertificateColumnNames.SubjectDnsNames} = @SUBJECTDNSNAMES WHERE {CertificateColumnNames.Id} = @ID";
+					foreach (var record in Find (null, false, X509CertificateRecordFields.Id | X509CertificateRecordFields.Certificate).ToArray ()) {
+						var statement = $"UPDATE {CertificatesTableName} SET {CertificateColumnNames.SubjectEmail} = @SUBJECTEMAIL, {CertificateColumnNames.SubjectDnsNames} = @SUBJECTDNSNAMES WHERE {CertificateColumnNames.Id} = @ID";
 
-							using (var command = connection.CreateCommand ()) {
-								command.AddParameterWithValue ("@ID", record.Id);
-								command.AddParameterWithValue ("@SUBJECTEMAIL", record.SubjectEmail);
-								command.AddParameterWithValue ("@SUBJECTDNSNAMES", EncodeDnsNames (record.SubjectDnsNames));
-								command.CommandType = CommandType.Text;
-								command.CommandText = statement;
+						using (var command = CreateDbCommand (connection)) {
+							command.AddParameterWithValue ("@ID", record.Id);
+							command.AddParameterWithValue ("@SUBJECTEMAIL", record.SubjectEmail);
+							command.AddParameterWithValue ("@SUBJECTDNSNAMES", EncodeDnsNames (record.SubjectDnsNames));
+							command.CommandType = CommandType.Text;
+							command.CommandText = statement;
 
-								command.ExecuteNonQuery ();
-							}
+							command.ExecuteNonQuery ();
 						}
-
-						transaction.Commit ();
-					} catch {
-						transaction.Rollback ();
-						throw;
 					}
-				}
+				});
 
 				// Remove some old indexes
 				RemoveIndex (connection, table.TableName, CertificateColumnNames.BasicConstraints, CertificateColumnNames.SubjectEmail, CertificateColumnNames.NotBefore, CertificateColumnNames.NotAfter);
@@ -435,7 +423,7 @@ namespace MimeKit.Cryptography {
 			var fingerprint = certificate.GetFingerprint ().ToLowerInvariant ();
 			var serialNumber = certificate.SerialNumber.ToString ();
 			var issuerName = certificate.IssuerDN.ToString ();
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 			var query = CreateSelectQuery (fields);
 
 			// FIXME: Is this really the best way to query for an exact match of a certificate?
@@ -467,7 +455,7 @@ namespace MimeKit.Cryptography {
 		/// <param name="fields">The fields to return.</param>
 		protected override DbCommand GetSelectCommand (DbConnection connection, MailboxAddress mailbox, DateTime now, bool requirePrivateKey, X509CertificateRecordFields fields)
 		{
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 			var query = CreateSelectQuery (fields);
 
 			query = query.Append (" WHERE ").Append (CertificateColumnNames.BasicConstraints).Append (" = @BASICCONSTRAINTS ");
@@ -521,7 +509,7 @@ namespace MimeKit.Cryptography {
 		/// <param name="fields">The fields to return.</param>
 		protected override DbCommand GetSelectCommand (DbConnection connection, ISelector<X509Certificate> selector, bool trustedAnchorsOnly, bool requirePrivateKey, X509CertificateRecordFields fields)
 		{
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 			var query = CreateSelectQuery (fields);
 			int baseQueryLength = query.Length;
 
@@ -655,7 +643,7 @@ namespace MimeKit.Cryptography {
 		protected override DbCommand GetSelectCommand (DbConnection connection, X509Name issuer, X509CrlRecordFields fields)
 		{
 			var query = CreateSelectQuery (fields).Append (" WHERE ").Append (CrlColumnNames.IssuerName).Append (" = @ISSUERNAME");
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 
 			command.CommandText = query.ToString ();
 			command.AddParameterWithValue ("@ISSUERNAME", issuer.ToString ());
@@ -681,7 +669,7 @@ namespace MimeKit.Cryptography {
 				.Append (CrlColumnNames.IssuerName).Append ("= @ISSUERNAME AND ")
 				.Append (CrlColumnNames.ThisUpdate).Append (" = @THISUPDATE LIMIT 1");
 			var issuerName = crl.IssuerDN.ToString ();
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 
 			command.CommandText = query.ToString ();
 			command.AddParameterWithValue ("@DELTA", crl.IsDelta ());
@@ -702,7 +690,7 @@ namespace MimeKit.Cryptography {
 		/// <param name="connection">The database connection.</param>
 		protected override DbCommand GetSelectAllCrlsCommand (DbConnection connection)
 		{
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 
 			command.CommandText = $"SELECT {CrlColumnNames.Id}, {CrlColumnNames.Crl} FROM {CrlsTableName}";
 			command.CommandType = CommandType.Text;
@@ -721,7 +709,7 @@ namespace MimeKit.Cryptography {
 		/// <param name="record">The certificate record.</param>
 		protected override DbCommand GetDeleteCommand (DbConnection connection, X509CertificateRecord record)
 		{
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 
 			command.CommandText = $"DELETE FROM {CertificatesTableName} WHERE {CertificateColumnNames.Id} = @ID";
 			command.AddParameterWithValue ("@ID", record.Id);
@@ -741,7 +729,7 @@ namespace MimeKit.Cryptography {
 		/// <param name="record">The record.</param>
 		protected override DbCommand GetDeleteCommand (DbConnection connection, X509CrlRecord record)
 		{
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 
 			command.CommandText = $"DELETE FROM {CrlsTableName} WHERE {CrlColumnNames.Id} = @ID";
 			command.AddParameterWithValue ("@ID", record.Id);
@@ -763,7 +751,7 @@ namespace MimeKit.Cryptography {
 		{
 			var statement = new StringBuilder ("INSERT INTO ").Append (CertificatesTableName).Append ('(');
 			var variables = new StringBuilder ("VALUES(");
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 			var columns = CertificatesTable.Columns;
 
 			for (int i = 1; i < columns.Count; i++) {
@@ -802,7 +790,7 @@ namespace MimeKit.Cryptography {
 		{
 			var statement = new StringBuilder ("INSERT INTO ").Append (CrlsTableName).Append ('(');
 			var variables = new StringBuilder ("VALUES(");
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 			var columns = CrlsTable.Columns;
 
 			for (int i = 1; i < columns.Count; i++) {
@@ -842,7 +830,7 @@ namespace MimeKit.Cryptography {
 		{
 			var statement = new StringBuilder ("UPDATE ").Append (CertificatesTableName).Append (" SET ");
 			var columns = GetColumnNames (fields & ~X509CertificateRecordFields.Id);
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 
 			for (int i = 0; i < columns.Length; i++) {
 				var value = GetValue (record, columns[i]);
@@ -880,7 +868,7 @@ namespace MimeKit.Cryptography {
 		protected override DbCommand GetUpdateCommand (DbConnection connection, X509CrlRecord record)
 		{
 			var statement = new StringBuilder ("UPDATE ").Append (CrlsTableName).Append (" SET ");
-			var command = connection.CreateCommand ();
+			var command = CreateDbCommand(connection);
 			var columns = CrlsTable.Columns;
 
 			for (int i = 1; i < columns.Count; i++) {
@@ -925,6 +913,39 @@ namespace MimeKit.Cryptography {
 			}
 
 			base.Dispose (disposing);
+		}
+		/// <summary>
+		/// Executes the specified action within a db transaction.
+		/// </summary>
+		/// <param name="connection"></param>
+		/// <param name="action"></param>
+		protected void ExecuteWithinTransaction (DbConnection connection, Action action)
+		{
+			using (var transaction = connection.BeginTransaction ()) {
+				activeTransaction = transaction;
+				try {
+					action.Invoke ();
+
+					transaction.Commit ();
+				} catch {
+					transaction.Rollback ();
+					throw;
+				} finally {
+					activeTransaction = null;
+				}
+			}
+		}
+		
+		/// <summary>
+		/// Creates a command with current transaction.
+		/// </summary>
+		/// <param name="connection"></param>
+		/// <returns></returns>
+		protected DbCommand CreateDbCommand (DbConnection connection)
+		{
+			var command = connection.CreateCommand();
+			command.Transaction = activeTransaction;
+			return command;
 		}
 	}
 }

--- a/MimeKit/Cryptography/SqliteCertificateDatabase.cs
+++ b/MimeKit/Cryptography/SqliteCertificateDatabase.cs
@@ -321,7 +321,7 @@ namespace MimeKit.Cryptography {
 		/// <returns>The list of columns.</returns>
 		protected override IList<DataColumn> GetTableColumns (DbConnection connection, string tableName)
 		{
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand(connection)) {
 				command.CommandText = $"PRAGMA table_info({tableName})";
 				using (var reader = command.ExecuteReader ()) {
 					var columns = new List<DataColumn> ();
@@ -422,7 +422,7 @@ namespace MimeKit.Cryptography {
 
 			statement.Append (')');
 
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand (connection)) {
 				command.CommandText = statement.ToString ();
 				command.CommandType = CommandType.Text;
 				command.ExecuteNonQuery ();
@@ -447,7 +447,7 @@ namespace MimeKit.Cryptography {
 			statement.Append (" ADD COLUMN ");
 			Build (statement, table, column, ref primaryKeys, false);
 
-			using (var command = connection.CreateCommand ()) {
+			using (var command = CreateDbCommand (connection)) {
 				command.CommandText = statement.ToString ();
 				command.CommandType = CommandType.Text;
 				command.ExecuteNonQuery ();


### PR DESCRIPTION
The following errors are fixed:
1. System.InvalidOperationException: 'There is already an open DataReader associated with this Connection which must be closed first.'
2. ExecuteNonQuery requires the command to have a transaction when the connection assigned to the command is in a pending local transaction. The Transaction property of the command has not been initialized
3. Fix add new column syntax for sql server