### PR TITLE
Check if disposed in MemoryBlockStream.ToArray

### DIFF
--- a/MimeKit/IO/MemoryBlockStream.cs
+++ b/MimeKit/IO/MemoryBlockStream.cs
@@ -79,8 +79,13 @@ namespace MimeKit.IO {
 		/// Copies all the stream data into a newly allocated byte array.
 		/// </remarks>
 		/// <returns>The array.</returns>
+		/// <exception cref="System.ObjectDisposedException">
+		/// The stream has been disposed.
+		/// </exception>
 		public byte[] ToArray ()
 		{
+			CheckDisposed ();
+
 			var array = new byte[length];
 			int need = (int) length;
 			int arrayIndex = 0;

--- a/UnitTests/IO/MemoryBlockStreamTests.cs
+++ b/UnitTests/IO/MemoryBlockStreamTests.cs
@@ -70,6 +70,23 @@ namespace UnitTests.IO {
 		}
 
 		[Test]
+		public void TestObjectDisposedExceptions ()
+		{
+			var block = new MemoryBlockStream ();
+			block.Dispose ();
+
+			Assert.Throws<ObjectDisposedException> (() => block.Read (buf, 0, buf.Length));
+			Assert.ThrowsAsync<ObjectDisposedException> (() => block.ReadAsync (buf, 0, buf.Length));
+			Assert.Throws<ObjectDisposedException> (() => block.Write (buf, 0, buf.Length));
+			Assert.ThrowsAsync<ObjectDisposedException> (() => block.WriteAsync (buf, 0, buf.Length));
+			Assert.Throws<ObjectDisposedException> (() => block.Seek (0, SeekOrigin.Begin));
+			Assert.Throws<ObjectDisposedException> (() => block.SetLength (0));
+			Assert.Throws<ObjectDisposedException> (block.Flush);
+			Assert.ThrowsAsync<ObjectDisposedException> (block.FlushAsync);
+			Assert.Throws<ObjectDisposedException> (() => block.ToArray ());
+		}
+
+		[Test]
 		public void TestCanReadWriteSeek ()
 		{
 			var buffer = new byte[1024];


### PR DESCRIPTION
This pull request add a unit test which checks that `MemoryBlockStream` correctly throws `ObjectDisposedException`. This was not the case for `MemoryBlockStream.ToArray` which is added in the second commit.

I found this while working on #1067 but opened a separate PR because strictly speaking this a behavioral change in public API.