### PR TITLE
Check if disposed on FilteredStream filter manipulation

### DIFF
--- a/MimeKit/IO/FilteredStream.cs
+++ b/MimeKit/IO/FilteredStream.cs
@@ -62,6 +62,7 @@ namespace MimeKit.IO {
 		/// </summary>
 		/// <remarks>
 		/// Creates a filtered stream using the specified source stream.
+		/// The source stream will be left open when this <see cref="FilteredStream"/> is disposed.
 		/// </remarks>
 		/// <param name="source">The underlying stream to filter.</param>
 		/// <exception cref="System.ArgumentNullException">
@@ -103,6 +104,8 @@ namespace MimeKit.IO {
 		/// </exception>
 		public void Add (IMimeFilter filter)
 		{
+			CheckDisposed ();
+
 			if (filter is null)
 				throw new ArgumentNullException (nameof (filter));
 
@@ -123,6 +126,8 @@ namespace MimeKit.IO {
 		/// </exception>
 		public bool Contains (IMimeFilter filter)
 		{
+			CheckDisposed ();
+
 			if (filter is null)
 				throw new ArgumentNullException (nameof (filter));
 
@@ -142,6 +147,8 @@ namespace MimeKit.IO {
 		/// </exception>
 		public bool Remove (IMimeFilter filter)
 		{
+			CheckDisposed ();
+
 			if (filter is null)
 				throw new ArgumentNullException (nameof (filter));
 

--- a/UnitTests/IO/FilteredStreamTests.cs
+++ b/UnitTests/IO/FilteredStreamTests.cs
@@ -35,6 +35,25 @@ namespace UnitTests.IO {
 		static readonly string DataDir = Path.Combine (TestHelper.ProjectDir, "TestData", "encoders");
 
 		[Test]
+		public void TestObjectDisposedExceptions ()
+		{
+			var filtered = new FilteredStream (new MemoryStream ());
+			filtered.Dispose ();
+
+			byte[] buf = new byte[1024];
+			Assert.Throws<ObjectDisposedException> (() => filtered.Read (buf, 0, buf.Length));
+			Assert.ThrowsAsync<ObjectDisposedException> (() => filtered.ReadAsync (buf, 0, buf.Length));
+			Assert.Throws<ObjectDisposedException> (() => filtered.Write (buf, 0, buf.Length));
+			Assert.ThrowsAsync<ObjectDisposedException> (() => filtered.WriteAsync (buf, 0, buf.Length));
+			Assert.Throws<ObjectDisposedException> (filtered.Flush);
+			Assert.ThrowsAsync<ObjectDisposedException> (filtered.FlushAsync);
+
+			Assert.Throws<ObjectDisposedException> (() => filtered.Add (DecoderFilter.Create (ContentEncoding.Base64)));
+			Assert.Throws<ObjectDisposedException> (() => filtered.Remove (DecoderFilter.Create (ContentEncoding.Base64)));
+			Assert.Throws<ObjectDisposedException> (() => filtered.Contains (DecoderFilter.Create (ContentEncoding.Base64)));
+		}
+
+		[Test]
 		public void TestCanReadWriteSeekTimeout ()
 		{
 			var buffer = new byte[1024];


### PR DESCRIPTION
This pull request add a unit test which checks that `FilteredStream` correctly throws `ObjectDisposedException`. This was not the case for `Add`, `Remove`, and `Contains` which is added in the second commit.

I was uncertain whether it would make sense to add a `leaveOpen` parameter here too. It has not been necessary so far and following the .NET pattern introducing a parameter `bool leaveOpen = false` would be potentially dangerous behavior change. Therefore, I decided to just a comment that the source stream won't be disposed.