### PR TITLE
Update to BouncyCastle.Cryptography 2.6.1

### DIFF
--- a/MimeKit/Cryptography/X509Certificate2Extensions.cs
+++ b/MimeKit/Cryptography/X509Certificate2Extensions.cs
@@ -25,15 +25,14 @@
 //
 
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
-using Org.BouncyCastle.X509;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Security;
 
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 using X509Certificate2 = System.Security.Cryptography.X509Certificates.X509Certificate2;
@@ -64,14 +63,11 @@ namespace MimeKit.Cryptography {
 			if (certificate == null)
 				throw new ArgumentNullException (nameof (certificate));
 
-			var rawData = certificate.GetRawCertData ();
-			var parser = new X509CertificateParser ();
-			var cert = parser.ReadCertificate (rawData);
-
-			if (cert == null)
+			try {
+				return DotNetUtilities.FromX509Certificate (certificate);
+			} catch {
 				throw new ArgumentException ("Cannot convert X509Certificate2 to a BouncyCastle X509Certificate.", nameof (certificate));
-
-			return cert;
+			}
 		}
 
 		/// <summary>
@@ -116,25 +112,23 @@ namespace MimeKit.Cryptography {
 			if (alt == null)
 				return Array.Empty<string> ();
 
-			using (var memory = new MemoryStream (alt.RawData, false)) {
-				var seq = Asn1Sequence.GetInstance (Asn1Object.FromByteArray (alt.RawData));
-				var names = new string[seq.Count];
-				int count = 0;
+			var seq = Asn1Sequence.GetInstance (alt.RawData);
+			var names = new string[seq.Count];
+			int count = 0;
 
-				foreach (Asn1Encodable encodable in seq) {
-					var name = GeneralName.GetInstance (encodable);
-					if (name.TagNo == tagNo)
-						names[count++] = ((IAsn1String) name.Name).GetString ();
-				}
-
-				if (count == 0)
-					return Array.Empty<string> ();
-
-				if (count < names.Length)
-					Array.Resize (ref names, count);
-
-				return names;
+			foreach (Asn1Encodable encodable in seq) {
+				var name = GeneralName.GetInstance (encodable);
+				if (name.TagNo == tagNo)
+					names[count++] = ((IAsn1String) name.Name).GetString ();
 			}
+
+			if (count == 0)
+				return Array.Empty<string> ();
+
+			if (count < names.Length)
+				Array.Resize (ref names, count);
+
+			return names;
 		}
 
 		/// <summary>
@@ -171,23 +165,22 @@ namespace MimeKit.Cryptography {
 
 		static EncryptionAlgorithm[] DecodeEncryptionAlgorithms (byte[] rawData)
 		{
-			using (var memory = new MemoryStream (rawData, false)) {
-				using (var asn1 = new Asn1InputStream (memory)) {
-					if (asn1.ReadObject () is not Asn1Sequence sequence)
-						return null;
-
-					var algorithms = new List<EncryptionAlgorithm> ();
-
-					for (int i = 0; i < sequence.Count; i++) {
-						var identifier = AlgorithmIdentifier.GetInstance (sequence[i]);
-
-						if (BouncyCastleSecureMimeContext.TryGetEncryptionAlgorithm (identifier, out var algorithm))
-							algorithms.Add (algorithm);
-					}
-
-					return algorithms.ToArray ();
-				}
+			AlgorithmIdentifier[] capabilities;
+			try {
+				// TODO Ideally would use SmimeCapabilities (containing SmimeCapability)
+				capabilities = Asn1Sequence.GetInstance (rawData).MapElements (AlgorithmIdentifier.GetInstance);
+			} catch {
+				return null;
 			}
+
+			var algorithms = new List<EncryptionAlgorithm> ();
+
+			foreach (AlgorithmIdentifier capability in capabilities) {
+				if (BouncyCastleSecureMimeContext.TryGetEncryptionAlgorithm (capability, out var algorithm))
+					algorithms.Add (algorithm);
+			}
+
+			return algorithms.ToArray ();
 		}
 
 		/// <summary>
@@ -210,6 +203,7 @@ namespace MimeKit.Cryptography {
 				throw new ArgumentNullException (nameof (certificate));
 
 			foreach (var extension in certificate.Extensions) {
+				// PkcsObjectIdentifiers.Pkcs9AtSmimeCapabilities
 				if (extension.Oid.Value == "1.2.840.113549.1.9.15") {
 					var algorithms = DecodeEncryptionAlgorithms (extension.RawData);
 

--- a/MimeKit/MimeKit.csproj
+++ b/MimeKit/MimeKit.csproj
@@ -81,7 +81,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MimeKit/MimeKit.csproj
+++ b/MimeKit/MimeKit.csproj
@@ -81,7 +81,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Cryptography/X509CertificateGenerator.cs
+++ b/UnitTests/Cryptography/X509CertificateGenerator.cs
@@ -453,7 +453,8 @@ namespace UnitTests.Cryptography {
 			generator.SetSubjectDN (subject);
 			generator.SetIssuerDN (issuer);
 
-			generator.AddExtension (X509Extensions.SubjectKeyIdentifier, false, new SubjectKeyIdentifierStructure (key.Public));
+			var subjectKeyIdentifier = X509ExtensionUtilities.CreateSubjectKeyIdentifier (key.Public);
+			generator.AddExtension (X509Extensions.SubjectKeyIdentifier, false, subjectKeyIdentifier);
 
 			if (certificateOptions.SubjectAlternativeNames != null) {
 				var altNames = new GeneralNames (certificateOptions.SubjectAlternativeNames.ToArray ());
@@ -474,8 +475,10 @@ namespace UnitTests.Cryptography {
 				generator.AddExtension (X509Extensions.CrlDistributionPoints, false, crlDistPoint);
 			}
 
-			if (issuerCertificate != null)
-				generator.AddExtension (X509Extensions.AuthorityKeyIdentifier, false, new AuthorityKeyIdentifierStructure (issuerCertificate));
+			if (issuerCertificate != null) {
+				var authorityKeyIdentifier = X509ExtensionUtilities.CreateAuthorityKeyIdentifier (issuerCertificate);
+				generator.AddExtension (X509Extensions.AuthorityKeyIdentifier, false, authorityKeyIdentifier);
+			}
 
 			if (!string.IsNullOrEmpty (options.BasicConstraints)) {
 				var basicConstraints = options.BasicConstraints.Split (new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/UnitTests/Cryptography/X509CrlGenerator.cs
+++ b/UnitTests/Cryptography/X509CrlGenerator.cs
@@ -48,7 +48,9 @@ namespace UnitTests.Cryptography {
 			crlGenerator.SetThisUpdate (thisUpdate);
 			crlGenerator.SetNextUpdate (nextUpdate);
 
-			crlGenerator.AddExtension (X509Extensions.AuthorityKeyIdentifier, false, new AuthorityKeyIdentifierStructure (authority.GetPublicKey ()));
+			var authorityKeyIdentifier = X509ExtensionUtilities.CreateAuthorityKeyIdentifier (authority.GetPublicKey ());
+			crlGenerator.AddExtension (X509Extensions.AuthorityKeyIdentifier, false, authorityKeyIdentifier);
+
 			crlGenerator.AddExtension (X509Extensions.CrlNumber, false, new CrlNumber (CrlNumberValue));
 			CrlNumberValue = CrlNumberValue.Add (BigInteger.One);
 


### PR DESCRIPTION
- fix references to obsolete methods
- refactor some BC usages