### PR TITLE
AuthenticationResults parsing now supports Gmail style headers

### DIFF
--- a/UnitTests/Cryptography/AuthenticationResultsTests.cs
+++ b/UnitTests/Cryptography/AuthenticationResultsTests.cs
@@ -1489,5 +1489,45 @@ namespace UnitTests.Cryptography {
 		{
 			AssertParseFailure ("authserv-id; method=pass ptype.prop=pvalue; office365.domain :", 61, 61);
 		}
+
+		[Test]
+		public void TestParseGmailAuthenticationResults ()
+		{
+			const string input = "mx.google.com; dkim=pass header.i=@sender.com header.s=15ca3b75e6386151 header.b=qsGI6Y43; gateway.spf=pass (google.com: domain receiver.com configured 1.2.3.4 as internal address) smtp.mailfrom=mail@from.com smtp.remote-ip=1.2.3.4 policy.d=receiver.com";
+			var buffer = Encoding.ASCII.GetBytes (input);
+			AuthenticationResults authres;
+
+			Assert.That (AuthenticationResults.TryParse (buffer, 0, buffer.Length, out authres), Is.True);
+			Assert.That (authres.AuthenticationServiceIdentifier, Is.EqualTo ("mx.google.com"), "authserv-id");
+			Assert.That (authres.Results.Count, Is.EqualTo (2), "methods");
+			Assert.That (authres.Results[0].Method, Is.EqualTo ("dkim"));
+			Assert.That (authres.Results[0].Result, Is.EqualTo ("pass"));
+			Assert.That (authres.Results[0].Properties.Count, Is.EqualTo (3), "dkim properties");
+			Assert.That (authres.Results[0].Properties[0].PropertyType, Is.EqualTo ("header"));
+			Assert.That (authres.Results[0].Properties[0].Property, Is.EqualTo ("i"));
+			Assert.That (authres.Results[0].Properties[0].Value, Is.EqualTo ("@sender.com"));
+			Assert.That (authres.Results[0].Properties[1].PropertyType, Is.EqualTo ("header"));
+			Assert.That (authres.Results[0].Properties[1].Property, Is.EqualTo ("s"));
+			Assert.That (authres.Results[0].Properties[1].Value, Is.EqualTo ("15ca3b75e6386151"));
+			Assert.That (authres.Results[0].Properties[2].PropertyType, Is.EqualTo ("header"));
+			Assert.That (authres.Results[0].Properties[2].Property, Is.EqualTo ("b"));
+			Assert.That (authres.Results[0].Properties[2].Value, Is.EqualTo ("qsGI6Y43"));
+
+			Assert.That (authres.Results[1].Method, Is.EqualTo ("gateway.spf"));
+			Assert.That (authres.Results[1].Result, Is.EqualTo ("pass"));
+			Assert.That (authres.Results[1].ResultComment, Is.EqualTo ("google.com: domain receiver.com configured 1.2.3.4 as internal address"));
+			Assert.That (authres.Results[1].Properties.Count, Is.EqualTo (3), "spf properties");
+			Assert.That (authres.Results[1].Properties[0].PropertyType, Is.EqualTo ("smtp"));
+			Assert.That (authres.Results[1].Properties[0].Property, Is.EqualTo ("mailfrom"));
+			Assert.That (authres.Results[1].Properties[0].Value, Is.EqualTo ("mail@from.com"));
+			Assert.That (authres.Results[1].Properties[1].PropertyType, Is.EqualTo ("smtp"));
+			Assert.That (authres.Results[1].Properties[1].Property, Is.EqualTo ("remote-ip"));
+			Assert.That (authres.Results[1].Properties[1].Value, Is.EqualTo ("1.2.3.4"));
+			Assert.That (authres.Results[1].Properties[2].PropertyType, Is.EqualTo ("policy"));
+			Assert.That (authres.Results[1].Properties[2].Property, Is.EqualTo ("d"));
+			Assert.That (authres.Results[1].Properties[2].Value, Is.EqualTo ("receiver.com"));
+
+			Assert.That (authres.ToString (), Is.EqualTo (input));
+		}
 	}
 }


### PR DESCRIPTION
The Current implementation of AuthenticationResults parsing logic does not support gmail style auth headers, returning error `Unexpected token after Office365 authserv-id token at offset {0}`.

This MR modifies the parsing logic to support Gmail style auth headers, example: `mx.google.com; dkim=pass header.i=@sender.com header.s=15ca3b75e6386151 header.b=qsGI6Y43; gateway.spf=pass (google.com: domain receiver.com configured 1.2.3.4 as internal address) smtp.mailfrom=mail@from.com smtp.remote-ip=1.2.3.4 policy.d=receiver.com`

This change switches from using SkipAtom to SkipKeyword, to stop SkipAtom consuming the `=` in `gateway.spf=pass` above, then adds support for recognising an O365 style authserv-id or a gmail style property with a `.` in it.

Feed back welcome, tests all pass, but i have not done any additional verification of the fix, if there is anything i can do please let me know.