### PR TITLE
Base64.DecodeFromUtf8 bug with active hardware acceleration

### DIFF
--- a/MimeKit/Encodings/Base64Decoder.cs
+++ b/MimeKit/Encodings/Base64Decoder.cs
@@ -267,7 +267,7 @@ namespace MimeKit.Encodings {
 			var utf8 = new ReadOnlySpan<byte> (inptr, remainingInput);
 			var decoded = new Span<byte> (outptr, remainingOutput);
 
-			var status = Base64.DecodeFromUtf8 (utf8, decoded, out int bytesRead, out int bytesWritten, false);
+			var status = Base64.DecodeFromUtf8 (utf8, decoded, out int bytesRead, out int bytesWritten, true);
 			outptr += bytesWritten;
 			inptr += bytesRead;
 


### PR DESCRIPTION
The method returns corrupt attachments with active hardware acceleration.
I lose 2 bytes in my email attachment. When I set isFinalBlock to `true`, everything is fine.

**my check method** provides valid attachments.
```cs
using var attachmentStream = new MemoryStream();
mimePartAttachment.Content.Stream.CopyTo(attachmentStream);
var attachmentBytes = attachmentStream.ToArray();

string base64String = Encoding.UTF8.GetString(attachmentBytes);
byte[] originalBytes = Convert.FromBase64String(base64String);
```

**DecodeToAsync** provides corrupt attachments.
```cs
await mimePartAttachment.Content.DecodeToAsync(attachmentStream);
var data = attachmentStream.ToArray();
```