### PR TITLE
Fix unused initialization of 'length' in MimeParser.ScanContent

### DIFF
--- a/MimeKit/MimeParser.cs
+++ b/MimeKit/MimeParser.cs
@@ -1404,7 +1404,7 @@ namespace MimeKit {
 
 		unsafe bool ScanContent (byte* inbuf, ref bool midline, ref bool[] formats)
 		{
-			int length = inputEnd - inputIndex;
+			int length;
 			byte* inptr = inbuf + inputIndex;
 			byte* inend = inbuf + inputEnd;
 			int startIndex = inputIndex;


### PR DESCRIPTION
Removed the unused initialization of the `length` variable in `MimeParser.ScanContent`. The variable is unconditionally reassigned later in the loop before it is ever read, making the initial calculation redundant.

Found by Linux Verification Center (linuxtesting.org) with SVACE.