### PR TITLE
InternetAddressListConverter: Convert an empty string to an empty InternetAddressList

### DIFF
--- a/MimeKit/InternetAddressList.cs
+++ b/MimeKit/InternetAddressList.cs
@@ -55,6 +55,8 @@ namespace MimeKit {
 	[TypeConverter (typeof (InternetAddressListConverter))]
 	public class InternetAddressList : IList<InternetAddress>, IEquatable<InternetAddressList>, IComparable<InternetAddressList>
 	{
+		internal static readonly InternetAddressList Empty = [];
+
 		readonly List<InternetAddress> list;
 
 		/// <summary>

--- a/MimeKit/InternetAddressListConverter.cs
+++ b/MimeKit/InternetAddressListConverter.cs
@@ -115,10 +115,11 @@ namespace MimeKit {
 		/// </exception>
 		public override object? ConvertFrom (ITypeDescriptorContext? context, CultureInfo? culture, object value)
 		{
-			if (value is string text)
-				return InternetAddressList.Parse (Options ?? ParserOptions.Default, text);
-
-			return base.ConvertFrom (context, culture, value);
+			return value switch {
+				"" => InternetAddressList.Empty,
+				string text => InternetAddressList.Parse (Options ?? ParserOptions.Default, text),
+				_ => base.ConvertFrom (context, culture, value)
+			};
 		}
 
 		/// <summary>
@@ -163,10 +164,11 @@ namespace MimeKit {
 		/// <param name="value">The <see cref="Object"/> to test for validity.</param>
 		public override bool IsValid (ITypeDescriptorContext? context, object? value)
 		{
-			if (value is string text)
-				return InternetAddressList.TryParse (Options ?? ParserOptions.Default, text, out _);
-
-			return base.IsValid (context, value);
+			return value switch {
+				"" => true,
+				string text => InternetAddressList.TryParse (Options ?? ParserOptions.Default, text, out _),
+				_ => base.IsValid (context, value)
+			};
 		}
 	}
 }

--- a/UnitTests/InternetAddressListConverterTests.cs
+++ b/UnitTests/InternetAddressListConverterTests.cs
@@ -41,11 +41,12 @@ namespace UnitTests
 			Assert.That (converter.CanConvertTo (typeof (string)), Is.True);
 		}
 
-		[Test]
-		public void TestIsValid ()
+		[TestCase ("")]
+		[TestCase ("Skye <skye@shield.gov>, Leo Fitz <fitz@shield.gov>, Melinda May <may@shield.gov>")]
+		public void TestIsValid (string value)
 		{
 			var converter = TypeDescriptor.GetConverter (typeof (InternetAddressList));
-			Assert.That (converter.IsValid ("Skye <skye@shield.gov>, Leo Fitz <fitz@shield.gov>, Melinda May <may@shield.gov>"), Is.True);
+			Assert.That (converter.IsValid (value), Is.True);
 		}
 
 		[Test]
@@ -66,10 +67,24 @@ namespace UnitTests
 		}
 
 		[Test]
+		public void TestConvertEmpty ()
+		{
+			var converter = TypeDescriptor.GetConverter (typeof (InternetAddressList));
+			var result = converter.ConvertFrom ("");
+			Assert.That (result, Is.InstanceOf (typeof (InternetAddressList)));
+
+			var list = (InternetAddressList) result;
+			Assert.That (list, Is.Empty);
+
+			var text = converter.ConvertTo (list, typeof (string));
+			Assert.That (text, Is.EqualTo (""));
+		}
+
+		[Test]
 		public void TestConvertNotValid ()
 		{
 			var converter = TypeDescriptor.GetConverter (typeof (InternetAddressList));
-			Assert.Throws<ParseException> (() => converter.ConvertFrom (""));
+			Assert.Throws<ParseException> (() => converter.ConvertFrom (" "));
 			Assert.Throws<NotSupportedException> (() => converter.ConvertFrom (5));
 			Assert.Throws<NotSupportedException> (() => converter.ConvertTo (new InternetAddressList (), typeof (int)));
 		}
@@ -78,7 +93,7 @@ namespace UnitTests
 		public void TestIsNotValid ()
 		{
 			var converter = TypeDescriptor.GetConverter (typeof (InternetAddressList));
-			Assert.That (converter.IsValid (""), Is.False);
+			Assert.That (converter.IsValid (" "), Is.False);
 			Assert.That (converter.IsValid (5), Is.False);
 		}
 


### PR DESCRIPTION
I think it makes sense to convert the empty string to an empty `InternetAddressList`. Also, this is really useful for configuration binding.