### PR TITLE
Fix potential NullReferenceException in CmsEnvelopeAddEllipticCurve

### DIFF
--- a/MimeKit/Cryptography/BouncyCastleSecureMimeContext.cs
+++ b/MimeKit/Cryptography/BouncyCastleSecureMimeContext.cs
@@ -1478,10 +1478,12 @@ namespace MimeKit.Cryptography {
 
 			var keyPair = keyGenerator.GenerateKeyPair ();
 
+			var subjectKeyIdentifier = recipient.RecipientIdentifierType == SubjectIdentifierType.SubjectKeyIdentifier
+				? X509ExtensionUtilities.GetSubjectKeyIdentifier (recipient.Certificate)
+				: null;
+
 			// TODO: better handle algorithm selection.
-			if (recipient.RecipientIdentifierType == SubjectIdentifierType.SubjectKeyIdentifier) {
-				// TODO Null check subjectKeyIdentifier?
-				var subjectKeyIdentifier = X509ExtensionUtilities.GetSubjectKeyIdentifier (recipient.Certificate);
+			if (subjectKeyIdentifier != null) {
 				cms.AddKeyAgreementRecipient (
 					CmsEnvelopedGenerator.ECDHSha1Kdf,
 					keyPair.Private,


### PR DESCRIPTION
Description of the issue:
In BouncyCastleSecureMimeContext.cs, the CmsEnvelopeAddEllipticCurve method attempts to retrieve the Subject Key Identifier from a recipient's certificate when SubjectIdentifierType.SubjectKeyIdentifier is specified. However, X509ExtensionUtilities.GetSubjectKeyIdentifier() returns null if the certificate does not contain this extension. Calling .GetKeyIdentifier() directly on this potentially null object leads to a NullReferenceException.

Proposed fix:
Added a null check for subjectKeyIdentifier. If the extension is missing (null), the code gracefully falls back to the cms.AddKeyAgreementRecipient overload that accepts the certificate directly. This approach resolves the pending // TODO comment and perfectly aligns with the existing fallback logic used elsewhere in the file (e.g., in CreateSignedDataGenerator).

Found by Linux Verification Center (linuxtesting.org) with SVACE.